### PR TITLE
Fix podman volume mount permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ To use Claude Code with Google Cloud's Vertex AI, you need to pass through your 
 ```bash
 podman run -it \
   --pull always \
+  --userns=keep-id \
   -e CLAUDE_CODE_USE_VERTEX=1 \
   -e CLOUD_ML_REGION=your-ml-region \
   -e ANTHROPIC_VERTEX_PROJECT_ID=your-project-id \
   -e DISABLE_AUTOUPDATER=1 \
-  -v ~/.config/gcloud:/home/claude/.config/gcloud:Z \
-  -v $(pwd):/workspace:Z \
+  -v ~/.config/gcloud:/home/claude/.config/gcloud:ro,z \
+  -v $(pwd):/workspace:z \
   -w /workspace \
   --name claude_code \
   ghcr.io/opendatahub-io/ai-helpers:latest
@@ -72,9 +73,12 @@ podman run -it \
 - `CLOUD_ML_REGION` - Your GCP region (e.g., `us-east5`)
 - `ANTHROPIC_VERTEX_PROJECT_ID` - Your GCP project ID
 
+**Rootless Podman:**
+- `--userns=keep-id` - Preserves host user ID mapping, required for the claude user to access mounted volumes
+
 **Volume Mounts:**
-- `-v ~/.config/gcloud:/home/claude/.config/gcloud:ro` - Passes through your gcloud authentication (read-only)
-- `-v $(pwd):/workspace` - Mounts your current directory into the container
+- `-v ~/.config/gcloud:/home/claude/.config/gcloud:ro,z` - Passes through your gcloud authentication (read-only with SELinux labeling)
+- `-v $(pwd):/workspace:z` - Mounts your current directory into the container
 
 ### Running Commands Non-Interactively
 
@@ -83,14 +87,15 @@ You can execute Claude Code commands directly without entering an interactive se
 ```bash
 podman run -it \
   --pull always \
+  --userns=keep-id \
   -e CLAUDE_CODE_USE_VERTEX=1 \
   -e CLOUD_ML_REGION=your-ml-region \
   -e ANTHROPIC_VERTEX_PROJECT_ID=your-project-id \
-  -v ~/.config/gcloud:/home/claude/.config/gcloud:Z \
-  -v $(pwd):/workspace:Z \
+  -v ~/.config/gcloud:/home/claude/.config/gcloud:ro,z \
+  -v $(pwd):/workspace:z \
   -w /workspace \
   --name claude_code \
-  ghcr.io/opendatahub-io/ai-helpers:latest
+  ghcr.io/opendatahub-io/ai-helpers:latest \
   --print "/hello-world:echo Hello from Claude Code!"
 ```
 


### PR DESCRIPTION
Add --userns=keep-id flag to podman run commands to fix volume mount
permission issues with rootless Podman on Linux. Without this flag,
the host user's UID gets mapped to root inside the container, making
mounted files inaccessible to the claude user.

Also change volume mounts to use :z (shared SELinux label) instead of
:Z (private label) to allow multiple containers to access the same
volumes simultaneously. Change gcloud mount to read-only for better
security.

Changes:
- Add --userns=keep-id flag to both podman run examples
- Change :Z to :z for all volume mounts (shared SELinux label)
- Change gcloud mount to :ro,z (read-only with shared label)
- Add Rootless Podman section documenting the flag

Assisted-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added rootless Podman section explaining user ID preservation in container execution
  * Updated all container execution commands with enhanced user ID mapping handling
  * Improved volume mount configurations with updated security labeling and mount semantics across command variants

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->