### PR TITLE
Add make, shellcheck, and tox to container image

### DIFF
--- a/images/claude/Containerfile
+++ b/images/claude/Containerfile
@@ -4,7 +4,6 @@ FROM quay.io/fedora/fedora:latest
 RUN dnf install -y nodejs \
 	npm \
     python3 \
-    python3-pip \
     python3-devel \
     fedora-packager \
     fedora-review \
@@ -13,6 +12,8 @@ RUN dnf install -y nodejs \
     rpmdevtools \
     curl \
     git \
+    make \
+    shellcheck \
     && dnf clean all
 
 # Install Claude Code CLI globally
@@ -26,10 +27,13 @@ RUN curl -LsSf https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/
     && chmod +x /usr/local/bin/oc
 
 # Install common Python tools
-RUN pip3 install --no-cache-dir \
+RUN uv pip install --system --no-cache \
     pytest \
     requests \
-    pyyaml
+    pyyaml \
+    ruff \
+    tox \
+    tox-uv
 
 # Create claude user
 RUN useradd -m -u 1000 -s /bin/bash claude
@@ -44,10 +48,6 @@ RUN mkdir -p /home/claude/.claude/plugins
 COPY ./images/claude/claude-settings.json /home/claude/.claude/settings.json
 COPY ./images/claude/known_marketplaces.json /home/claude/.claude/plugins/known_marketplaces.json
 RUN chown -R claude:claude /home/claude/.claude
-
-# Create workspace directory
-RUN mkdir -p /workspace && chown -R claude:claude /workspace
-WORKDIR /workspace
 
 # Switch to claude user
 USER claude


### PR DESCRIPTION
# Pull Request Description

## Summary

Adds a couple dev-related dependencies.

Also, since we already install `uv` inside of the image, we might as well use it for installation to make things faster.

Creating the workspace directory is not necessary when mounting the local directory using the same path as on the host (see 1bbd4099).

## Type of Contribution
<!-- Check all that apply -->
- [x] 🏗️ Infrastructure/tooling

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image with improved Python package management approach.
  * Added development tools (make, shellcheck, ruff, and tox) for enhanced development capabilities.
  * Streamlined container configuration and removed unnecessary directory setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->