### PR TITLE
Fix mobile navbar overlapping search/filter elements

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -92,7 +92,7 @@
         }
 
         body {
-            padding-top: 120px;
+            padding-top: 120px; /* fallback; dynamically set by ResizeObserver */
         }
 
         .navbar-content {
@@ -2019,6 +2019,23 @@
 
         // Load data on page load
         loadData();
+
+        // Dynamically sync body padding-top with actual navbar height
+        (function() {
+            var navbar = document.querySelector('.navbar');
+            if (!navbar) return;
+            function syncPadding() {
+                document.body.style.paddingTop = navbar.offsetHeight + 'px';
+            }
+            if (typeof ResizeObserver !== 'undefined') {
+                new ResizeObserver(syncPadding).observe(navbar);
+            } else {
+                // Fallback for older browsers
+                syncPadding();
+                window.addEventListener('resize', syncPadding);
+            }
+            syncPadding();
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
# Pull Request Description

## Summary

Use ResizeObserver to dynamically sync body padding-top with the
navbar's actual measured height, instead of guessing with static
calc() + viewport units which don't track real content height.

- Add ResizeObserver on .navbar that sets body.style.paddingTop to
  navbar.offsetHeight whenever the navbar resizes
- Fall back to window resize listener for older browsers
- Remove fragile per-breakpoint body padding overrides that used
  calc(var(--navbar-base-height) + Nvh)
- Keep a CSS fallback padding-top: 120px for pre-JS rendering

Fixes #58

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [X] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [ ] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made

The fixed navbar becomes taller in mobile breakpoints due to responsive
layout changes (vertical stacking), but body padding-top remained static
at 120px, causing search bar and filters to be hidden under the navbar.

- Add responsive body padding-top adjustments:
  - ≤1280px: increase to 160px
  - ≤480px: increase to 200px
- Ensures search and filter elements are fully visible on mobile devices


## Testing

I manually tested it on my mobile and the view was good.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navbar height now syncs dynamically with page content so header spacing updates automatically as the navbar resizes.
* **Style**
  * Improved top-page padding and responsive spacing to prevent layout shifts across screen sizes.
* **Bug Fixes**
  * Added a fallback for older browsers to maintain correct header spacing when automatic resizing isn't supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->