### PR TITLE
Add make command for running local docs server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,9 @@ build: ## Build Claude container image using Containerfile
 .PHONY: container-build
 container-build: build ## Alias for build target
 
+.PHONY: docs
+docs: ## Run docs locally at http://localhost:8000
+	@echo "Starting local documentation server..."
+	@python3 -m http.server 8000 --directory docs
+
 .DEFAULT_GOAL := help

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,8 @@ This directory contains the Github Pages website for the ODH ai-helpers project.
 The website data is generated from the repository structure:
 
 ```bash
-# From repository root
 python3 scripts/build-website.py
+# Execute from repo root; also executed when you run `make build`
 ```
 
 This extracts information from:
@@ -29,9 +29,8 @@ This extracts information from:
 To test the website locally:
 
 ```bash
-cd docs
-python3 -m http.server 8000
-# Visit http://localhost:8000
+make docs
+# Execute from repo root; visit http://localhost:8000
 ```
 
 ## Deployment
@@ -47,5 +46,3 @@ When plugins or commands are added/modified:
 1. Run `python3 scripts/build-website.py` to regenerate `data.json`
 2. Commit both `data.json` and any changes
 3. Push to trigger Github Pages rebuild
-
-Alternatively, set up a Github workflow to automatically rebuild on changes.


### PR DESCRIPTION
# Pull Request Description

## Summary

Having to remember the Python `http.server` init command is annoying, so let's just run it with `make docs`.

## Type of Contribution
- [x] 🏗️ Infrastructure/tooling

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new command to serve documentation locally at http://localhost:8000 for convenient offline access during development.

* **Documentation**
  * Updated documentation instructions to use the new local serve command and simplified local usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->