### PR TITLE
feat: Make Claude Code CLI available system-wide in container

### DIFF
--- a/images/claude/Containerfile
+++ b/images/claude/Containerfile
@@ -64,8 +64,11 @@ USER claude
 # Install Claude Code CLI as the claude user
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-# Add Claude Code to PATH
-ENV PATH="/home/claude/.local/bin:${PATH}"
+# Copy Claude Code binary to system location and make it available system-wide
+USER root
+RUN cp /home/claude/.local/bin/claude /usr/bin/claude && \
+    chmod +x /usr/bin/claude
+USER claude
 
 # Set Claude Code as the default command
 ENTRYPOINT ["claude"]


### PR DESCRIPTION
# Pull Request Description

## Summary

Copy Claude binary from ~/.local/bin to /usr/bin to make it accessible
to all users in the container, rather than just the claude user.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [X] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime configuration to optimize how the Claude Code CLI binary is installed and made available within the environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->