### PR TITLE
python-packaging skills/agent: always build from source, use pre-built only when source unavailable AND wheels exist

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -219,8 +219,7 @@
         "category": "general",
         "file_path": "helpers/agents/python-packaging-investigator.md",
         "id": "python-packaging-investigator",
-        "tools": "Bash, Read, Grep, Glob, WebFetch, Skill",
-        "model": "sonnet"
+        "tools": "Bash, Read, Grep, Glob, WebFetch, Skill"
       }
     ]
   }

--- a/helpers/agents/python-packaging-investigator.md
+++ b/helpers/agents/python-packaging-investigator.md
@@ -2,7 +2,6 @@
 name: python-packaging-investigator
 description: Investigates Python package repositories to analyze build systems, dependencies, and packaging complexity. Provides comprehensive guidance on how packages can be built from source using integrated analysis skills.
 tools: Bash, Read, Grep, Glob, WebFetch, Skill
-model: sonnet
 ---
 
 # Python Package Build Investigation Specialist
@@ -155,7 +154,7 @@ ALWAYS use this exact template structure:
 # [Package Name] Build Analysis
 
 ## Executive summary
-[One-paragraph overview covering build complexity (Simple/Moderate/Complex), primary blockers (Dependencies/Compilation/Licensing/None), and recommended approach (wheel install/conda/source build/container)]
+[One-paragraph overview covering build complexity (Simple/Moderate/Complex), primary blockers (Dependencies/Compilation/Licensing/None), and recommended approach (source build with customizations/pre-built only when source unavailable AND wheels exist/container)]
 
 ## Key findings
 - Source repository: [repository URL and confidence level from source-finder skill]
@@ -166,7 +165,7 @@ ALWAYS use this exact template structure:
 - Environment variables: [key customization options from env-finder skill]
 
 ## Recommendations
-1. [Primary build approach, either pre-built or from source with customizations]
+1. [Always build from source with customizations. Use pre-built wheels ONLY when: source unavailable (proprietary) AND wheels exist on PyPI]
 3. [Known issue resolution if applicable]
 ```
 

--- a/helpers/skills/python-packaging-complexity/SKILL.md
+++ b/helpers/skills/python-packaging-complexity/SKILL.md
@@ -87,14 +87,14 @@ Based on the analysis, provide specific guidance:
 
 ### For High Complexity Packages
 - "This package requires significant compilation infrastructure"
-- "Consider using pre-built wheels when available"
+- "Building from source with customizations is recommended"
 - "Building from source will need: [specific tools]"
-- "Estimated build time: [timeframe]"
+- "Use pre-built wheels only when: source unavailable (proprietary) AND wheels exist on PyPI"
 
 ### For Wheel Building Strategies
-- "Universal wheels available - use those for maximum compatibility"
+- "Always build from source with customizations for maximum control"
 - "Platform-specific wheels needed for: [platforms]"
-- "Source build recommended for: [specific scenarios]"
+- "Use pre-built wheels only when: source unavailable (proprietary) AND wheels exist on PyPI"
 - "Dependencies that complicate building: [list]"
 
 ### For Development Planning

--- a/scripts/build-website.py
+++ b/scripts/build-website.py
@@ -215,14 +215,18 @@ def get_tool_metadata(tool: Dict, category: str, base_path: Path) -> Dict:
                         frontmatter_content = content[4:end_marker]
                         agent_data = yaml.safe_load(frontmatter_content)
 
-                        metadata.update(
-                            {
-                                "description": agent_data.get("description", ""),
-                                "id": tool["name"],
-                                "tools": agent_data.get("tools", ""),
-                                "model": agent_data.get("model", ""),
-                            }
-                        )
+                        metadata_updates = {
+                            "description": agent_data.get("description", ""),
+                            "id": tool["name"],
+                            "tools": agent_data.get("tools", ""),
+                        }
+
+                        # Only include model if it's not empty
+                        model = agent_data.get("model", "")
+                        if model:
+                            metadata_updates["model"] = model
+
+                        metadata.update(metadata_updates)
             except Exception as e:
                 print(f"Warning: Could not read agent metadata from {agent_file}: {e}")
 
@@ -231,8 +235,6 @@ def get_tool_metadata(tool: Dict, category: str, base_path: Path) -> Dict:
             metadata["id"] = tool["name"]
         if "tools" not in metadata:
             metadata["tools"] = ""
-        if "model" not in metadata:
-            metadata["model"] = ""
 
     elif tool_type == "gem":
         # For gems, get description and link from gems.yaml by matching tool name


### PR DESCRIPTION
# Pull Request Description

## Summary

- Changed guidance to prioritize source builds with customizations as default approach
- Pre-built packages only acceptable when both conditions met:
  1. Source code unavailable (proprietary software)
  2. Wheels available on PyPI
- Updated both python-packaging-complexity skill and python-packaging-investigator agent

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [X] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [ ] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Python packaging guidance to prioritize building from source with customizations; pre-built wheels are now a fallback only when source is unavailable and wheels exist.
  * Clarified recommendations for high-complexity packages and wheel-building strategies.

* **Chores**
  * Adjusted agent metadata handling so an empty/default model field is no longer included in published metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->