### PR TITLE
feat: add stale PR management workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -61,6 +61,18 @@
   description: Still being worked on
   color: yellow
 
+- name: stale
+  description: No recent activity, may be closed
+  color: ededed
+
+- name: blocked
+  description: Blocked by external dependencies or issues
+  color: b60205
+
+- name: on-hold
+  description: Temporarily on hold, do not mark as stale
+  color: fbca04
+
 # Type of contribution
 - name: new-command
   description: Contribution adds a new command

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,59 @@
+name: Stale PR Management
+
+on:
+  schedule:
+    # Run daily at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Mark/Close stale PRs
+      uses: actions/stale@v10
+      with:
+        # Only target pull requests, not issues
+        only-pr-labels: ''
+
+        # Days before PR is considered stale
+        days-before-stale: 14
+
+        # Days before a stale PR is closed (set to -1 to disable auto-closing)
+        days-before-close: -1
+
+        # Label to apply to stale PRs
+        stale-pr-label: 'stale'
+
+        # Message to comment on stale PRs
+        stale-pr-message: |
+          This pull request has been inactive for 2 weeks and is now marked as stale.
+
+          **To keep this PR active:**
+          - Add new commits to address any feedback
+          - Respond to review comments
+          - Update the description if needed
+
+          **If this PR is still relevant:**
+          - Remove the `stale` label to reset the timer
+          - Leave a comment explaining the current status
+
+          This PR will remain open but may be closed in the future if it continues to be inactive.
+
+          Thank you for your contribution! 🚀
+
+        # Don't process PRs with these labels
+        exempt-pr-labels: 'blocked,on-hold,work-in-progress,wip'
+
+        # Remove stale label when PR becomes active again
+        remove-stale-when-updated: true
+
+        # Enable debug output
+        debug-only: false
+
+        # Don't process draft PRs
+        exempt-draft-pr: true


### PR DESCRIPTION
# Pull Request Description

## Summary
Add GitHub workflow to automatically manage inactive PRs.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [X] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made

- Mark PRs as stale after 2 weeks of inactivity
- Post helpful comments with guidance for contributors
- Exempt blocked, on-hold, and draft PRs
- Remove stale label when activity resumes

Also add supporting labels for better PR lifecycle management:
- stale: for inactive PRs
- blocked: for PRs waiting on dependencies
- on-hold: for temporarily paused PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added three new labels for organizing pull requests and issues: stale (for inactive items), blocked (for external blockers), and on-hold (for temporarily paused work).
  * Configured automated workflow to identify and flag stale pull requests based on inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->