### PR TITLE
Replace Fedora base image with UBI10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,17 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+
+  # Enable version updates for container base images
+  - package-ecosystem: "docker"
+    directory: "/images/claude"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    reviewers:
+      - "@opendatahub-io/ai-helpers-maintainers"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"

--- a/images/claude/Containerfile
+++ b/images/claude/Containerfile
@@ -1,21 +1,32 @@
-FROM quay.io/fedora/fedora:latest
+FROM registry.access.redhat.com/ubi10/ubi:10.1@sha256:1b616c4a90d6444b394d5c8f4bd9e15a394d95dd628925d0ec80c257fdc5099c
 
-# Install Node.js, NPM, Python 3, development tools, and RPM tools
+# Install Node.js (includes NPM), Python 3, development tools, and RPM tools
 RUN dnf install -y nodejs \
-	npm \
     python3 \
     python3-devel \
-    fedora-packager \
-    fedora-review \
-    mock \
     rpm-build \
     rpmdevtools \
     curl \
     git \
     make \
-    shellcheck \
     which \
     && dnf clean all
+
+# Install ShellCheck from pre-built binary (not available in UBI repos)
+ARG SHELLCHECK_VERSION=v0.11.0
+ARG SHELLCHECK_SHA256_X86_64=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+ARG SHELLCHECK_SHA256_AARCH64=12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e261eaa7e7c14588
+RUN set -eu; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64)  expected="$SHELLCHECK_SHA256_X86_64" ;; \
+      aarch64) expected="$SHELLCHECK_SHA256_AARCH64" ;; \
+      *) echo "Unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -LsSf -o /tmp/shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${arch}.tar.xz"; \
+    echo "${expected}  /tmp/shellcheck.tar.xz" | sha256sum -c -; \
+    tar xJf /tmp/shellcheck.tar.xz --strip-components=1 -C /usr/local/bin/ "shellcheck-${SHELLCHECK_VERSION}/shellcheck"; \
+    rm -f /tmp/shellcheck.tar.xz
 
 
 RUN echo '[google-cloud-cli]' > /etc/yum.repos.d/google-cloud-sdk.repo && \


### PR DESCRIPTION
## Summary

Switches the Claude Code container image (`images/claude/Containerfile`) from `quay.io/fedora/fedora:latest` to `registry.access.redhat.com/ubi10/ubi:10.1` (digest-pinned) for a stable, enterprise-supported base with regular security updates and CVE tracking.

Configures Dependabot to auto-bump the base image digest weekly.

## Changes

### Containerfile (`images/claude/Containerfile`)

- **Base image**: `quay.io/fedora/fedora:latest` → `registry.access.redhat.com/ubi10/ubi:10.1@sha256:...` (digest-pinned)
- **Removed packages** not available on UBI10:
  - `fedora-packager`, `fedora-review`, `mock` — these are Fedora-specific. Verified that **no skill, command, or agent** in `helpers/` references any of these tools — they are unused.
  - `npm` — bundled with `nodejs` on UBI10, no separate package needed.
- **shellcheck**: Installed from [GitHub releases](https://github.com/koalaman/shellcheck/releases) binary instead of dnf (not in UBI repos). Architecture-aware (`uname -m`) for multi-arch builds.
- **Kept as-is**: `rpm-build`, `rpmdevtools` (available on UBI10), Google Cloud CLI (`el10` repo works), `uv`, `oc`, Python tools, Claude Code install, user setup.

### Dependabot (`.github/dependabot.yml`)

- Added `docker` ecosystem entry for `images/claude` to auto-bump the base image digest weekly.

## Testing

- Built locally with `podman build` — all steps pass
- Smoke tested with `podman run --rm <image> --version` — Claude Code runs correctly

## Impact on other images

The Cursor Containerfile (`images/cursor/Containerfile`) is **not changed** in this PR. If this approach works well, a follow-up PR can apply the same changes there.

Signed-off-by: Jakub Rusz <jrusz@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated container build to use Red Hat UBI 10 as base image
  * Optimized container package dependencies
  * Enhanced automated dependency management configuration for CI pipelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->