### PR TITLE
added new skill jira-daily-recap

### DIFF
--- a/categories.yaml
+++ b/categories.yaml
@@ -37,6 +37,7 @@ Jira Management:
   - jira-workitem-attach
   - jira-workitem-search
   - jira-activity
+  - jira-daily-recap
   - jira-upload-chat-log
 
 CVE Remediation:

--- a/docs/data.json
+++ b/docs/data.json
@@ -286,6 +286,14 @@
         "allowed_tools": "Read Write Bash Skill"
       },
       {
+        "name": "jira-daily-recap",
+        "description": "Post a daily work summary as a Jira comment by collecting GitHub commits/PRs and Cursor chat history for the day. Use when the user asks to update a Jira ticket with today's work, log daily progress on a ticket, post a Jira comment with what was done, or runs /jira-daily-recap.",
+        "category": "jira management",
+        "file_path": "helpers/skills/jira-daily-recap/SKILL.md",
+        "id": "jira-daily-recap",
+        "allowed_tools": "Bash, Atlassian MCP"
+      },
+      {
         "name": "jira-status-summary",
         "description": "Update the Status Summary and Color Status fields on AIPCC Feature and Initiative tickets. Fetches child ticket activity via the jira-activity skill, generates a brief summary and sets the red/yellow/green color status. Use when asked to update the status summary for a Jira ticket.\n",
         "category": "aipcc",

--- a/helpers/skills/jira-daily-recap/SKILL.md
+++ b/helpers/skills/jira-daily-recap/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: jira-daily-recap
+description: >-
+  Post a daily work summary as a Jira comment by collecting GitHub commits/PRs
+  and Cursor chat history for the day. Use when the user asks to update a Jira
+  ticket with today's work, log daily progress on a ticket, post a Jira comment
+  with what was done, or runs /jira-daily-recap.
+user-invocable: true
+argument-hint: "<JIRA-KEY> <owner/repo> [branch] [date]"
+allowed-tools: "Bash, Atlassian MCP"
+---
+
+# Jira Daily Recap
+
+Collect a single day's GitHub activity and Cursor chat history **scoped to the
+specified repository/project**, then post a concise comment on a Jira ticket
+summarizing what was accomplished on that project only.
+
+## Prerequisites
+
+- **`gh`** CLI authenticated (`gh auth status` succeeds).
+- Jira access via Atlassian MCP.
+- Optional: local Cursor **`~/.cursor/projects/.../agent-transcripts/`** for chat history.
+
+## Usage
+
+```text
+/jira-daily-recap <JIRA-KEY> <owner/repo> [branch] [date]
+```
+
+- `JIRA-KEY` — required (e.g. `RHOAIENG-12345`)
+- `owner/repo` — required GitHub repository (e.g. `openshift/kubeflow`)
+- `branch` — optional; defaults to the repo's default branch
+- `date` — optional `YYYY-MM-DD`; defaults to **today**. When provided, collect
+  activity only for that specific date (not a range from that date to today).
+  Give an **IANA timezone** alongside natural-language dates so `TARGET_TZ` is
+  unambiguous.
+
+If the user omits required arguments, ask for them before proceeding.
+Natural-language dates must resolve to **`YYYY-MM-DD`**, validate
+`^\d{4}-\d{2}-\d{2}$`, and be a real calendar date; reject ambiguous inputs.
+
+## Procedure
+
+Execute the full numbered flow (validation → identities → GitHub → transcripts
+→ gate → compose → post → echo), including failure handling and the example,
+in **`references/workflow.md`**.
+
+## Gotchas / caveats
+
+- **Never** use `git config user.name` as the GitHub `author=` parameter — use a
+  real login or email-based post-filter as described in the workflow reference.
+- **Validate `owner` and `repo` before any API, shell, or filesystem use** —
+  malformed values can confuse paths or injected CLI arguments.
+- **Default timezone** when the user omits one: **`TARGET_TZ` = UTC** — "today"
+  and commit timestamps may differ from the user's local midnight.
+- **Wrong Cursor project folder** (slug mismatch, symlink escape): always
+  canonicalize paths and ensure the transcript directory is a **strict
+  subdirectory** of `~/.cursor/projects` before reading `.jsonl` files.
+- **`gh` CLI fails**: if `gh api` errors out, fall back to authenticated `curl`
+  (token via `gh auth token`); if all GitHub sources fail, compose from
+  transcripts only but **Step 4** still blocks a post when nothing qualifies for
+  **`TARGET_DATE`**.
+- **Jira markdown**: sanitize commit titles, PR titles, and transcript text before
+  `commentBody` — do not paste unescaped control markup or arbitrary HTML-like
+  payloads.

--- a/helpers/skills/jira-daily-recap/references/workflow.md
+++ b/helpers/skills/jira-daily-recap/references/workflow.md
@@ -1,0 +1,238 @@
+# Jira daily recap — full workflow
+
+Detailed steps for **`jira-daily-recap`**. The skill root describes usage; execute this document when running the recap.
+
+---
+
+## 0. Validate `owner` and `repo` (before any GitHub, shell, or filesystem use)
+
+- Split the required `owner/repo` argument into `owner` and `repo`.
+- Verify **each** segment matches `^[A-Za-z0-9._-]+$`. Reject `/`, `\`,
+  whitespace, shell metacharacters, or oversized strings — **stop** with a
+  clear error. Reuse this validated pair unchanged in Steps 2, 3, and all
+  `gh api` / `curl` calls (no late re-parsing).
+
+## Step-by-Step
+
+### 1. Resolve identities
+
+- **Validate `JIRA-KEY`** — must match `^[A-Za-z][A-Za-z0-9]+-\d+$`. If it does
+  not, stop and ask for a valid key (prevents injection oddities in API calls).
+- **GitHub username (must be login handle, not display name)** — resolve in order
+  until one returns a plausible GitHub handle:
+  1. `gh api /user --jq .login`.
+  2. `git config github.user`.
+  3. Optionally parse `git remote get-url origin` when it clearly encodes the
+     contributor handle (e.g. `git@github.com:LOGIN/somerepo.git` → take `LOGIN`
+     before the first slash only if `LOGIN` fits `^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$`).
+  If still unresolved after the chain above, either **ask the user for their
+  GitHub login** or — if `git config user.email` returns a value — fetch commits
+  without `--author` and **post-filter** where `commit.author.email` (or
+  `committer.email`) equals that address (case-normalized), still applying
+  **`TARGET_DATE` / `TARGET_TZ`** filtering. Do **not** use `git config user.name`
+  as an author filter.
+- **Jira cloud ID** — call Jira MCP `getAccessibleAtlassianResources` to get the
+  `cloudId`.
+- **Validate ticket** — call Jira MCP `getJiraIssue` with `cloudId` and
+  `issueIdOrKey` (the JIRA-KEY) to confirm the ticket exists. Use
+  `responseContentFormat: "markdown"`. Extract the issue summary for context.
+
+### 2. Collect GitHub activity (target date only)
+
+- Let `TARGET_TZ` = timezone for calendar boundaries: use an IANA name the user
+  gives (or names alongside "today"); if none is given, use **UTC** and note
+  that choice when summarizing dates.
+- Derive **`TARGET_DATE`** as `YYYY-MM-DD` **in `TARGET_TZ`** — user-supplied
+  date interpreted in `TARGET_TZ`, or local "today" in `TARGET_TZ` when none is
+  given.
+
+**Commits:**
+
+- Use the **`gh` CLI** to fetch commits:
+
+```bash
+gh api "repos/<owner>/<repo>/commits?sha=<branch>&author=<username>&per_page=100" --jq '.[] | {sha: .sha[0:7], date: .commit.author.date, msg: (.commit.message | split("\n") | .[0])}'
+```
+
+  When using email-based post-filter (no login resolved), omit `&author=` and
+  filter client-side as described in step 1.
+- If `gh api` fails, fall back to an authenticated `curl` request against
+  `https://api.github.com/repos/<owner>/<repo>/commits?...` (use the token from
+  `gh auth token` or the environment).
+- For each commit, read the author timestamp from `.commit.author.date`. Parse
+  ISO 8601 strictly; if parsing fails, treat that commit as **non-matching** for
+  the date filter (do not guess). Convert successful parses to **`TARGET_TZ`**
+  and compare the calendar date to **`TARGET_DATE`**.
+- Keep: commit message (first line) and SHA (short, first 7 chars).
+- If no commits match after conversion, record zero commits — do NOT pull other
+  days.
+
+**Pull Requests:**
+
+- Build the search query as `repo:<owner>/<repo> updated:<TARGET_DATE>..<TARGET_DATE>`
+  (GitHub's `..` is inclusive; same date twice restricts to that calendar day).
+  **Append** `author:<username>` only when step 1 yielded a definite GitHub login.
+
+```bash
+gh api "search/issues?q=repo:<owner>/<repo>+is:pr+author:<username>+updated:<TARGET_DATE>..<TARGET_DATE>" --jq '.items[] | {number, title, state, html_url, updated_at}'
+```
+
+  If `gh api` fails, fall back to `curl` with the same URL against
+  `https://api.github.com/search/issues`.
+- For each candidate PR, prefer `updated_at`; if merging/closing dominates the
+  story, also inspect `merged_at` / `closed_at` when present — normalize each
+  timestamp into **`TARGET_TZ`** and keep the PR **only when at least one of
+  these dates has calendar day `TARGET_DATE`**.
+- Keep: PR title, number, state (open/closed/merged), URL.
+
+### 3. Collect Cursor chat history (target date only, scoped to repo)
+
+- Reapply the **`owner` / `repo` checks from Step 0** if inputs could have changed;
+  inputs must remain the validated segments only.
+- Identify the Cursor project folder that corresponds to the specified
+  `owner/repo`. Transcript directories live under `~/.cursor/projects/` with
+  platform-specific slugs (e.g. `Users-<user>-CODING-<repo>` on macOS,
+  `home-<user>-<repo>` on Linux). Match on the **repo name portion** of the
+  workspace slug.
+- After resolving the project folder, **canonicalize** both the Cursor projects
+  base (`~/.cursor/projects` expanded) and the candidate directory with `realpath`
+  / `Path.resolve` (or equivalent). Ensure the project's resolved path **is that
+  base directory or a strict subdirectory**: compare path segments so the base
+  is a proper ancestor (not a brittle string prefix against paths like `.../projects_evil`).
+  Reject `..`, escapes via symlinks, or anything outside the base.
+- List `.jsonl` files **only under that project's** `agent-transcripts/` folder.
+  Use file mtime as a quick pre-filter: skip files last modified before
+  `TARGET_DATE` (they cannot contain messages from that day).
+- **Do NOT** collect transcripts from other project folders — only the project
+  matching the specified repo is in scope.
+- For each candidate `.jsonl` file, read its lines and extract user messages:
+  - If a JSON line contains a timestamp field (e.g. `createdAt`, `timestamp`),
+    parse it to instant, convert into **`TARGET_TZ`**, and **only include
+    messages whose local calendar date equals `TARGET_DATE`.**
+  - If no per-line timestamp is available, fall back to the file's mtime —
+    convert mtime instant to **`TARGET_TZ`** — include messages only when that
+    local calendar date is **`TARGET_DATE`**.
+  - Prefer text inside `<user_query>...</user_query>` tags.
+  - Fall back to the first 200 chars of user message text.
+- Never include messages from other dates regardless of filtering method.
+- Distill into a short list of what the user worked on / asked the agent to do
+  **for this project/Jira ticket**.
+- Deduplicate similar entries. Aim for 3-5 distinct activity bullets.
+- Ignore meta/skill invocations (e.g. `/jira-daily-recap`, `/update-internship-tasks`,
+  single-word messages, or messages that are only tool scaffolding).
+- **Exclude any work unrelated to the specified repo or Jira ticket** — even if
+  it appears in matching transcripts (e.g. side conversations about other projects).
+- **Only extract concrete, actionable progress** — code changes, bug fixes, new
+  features, config updates, PR/review work, or investigation with a clear outcome.
+  Discard casual conversation, questions about how things work, troubleshooting
+  that led nowhere, setup/environment chatter, and requests to run this skill.
+  If a transcript message didn't result in a tangible deliverable, skip it.
+
+### 4. Gate check — verify real activity exists for TARGET_DATE
+
+Before composing any comment, confirm that **at least one** of the following is true:
+
+- There is at least one GitHub commit whose author date lands on **`TARGET_DATE`**
+  in **`TARGET_TZ`** (per step 2).
+- There is at least one PR that step 2 kept for **`TARGET_DATE`** (normalized
+  timestamps in **`TARGET_TZ`**).
+- Step 3 yields **at least one substantive user message** that would appear in the
+  recap using the same **`TARGET_DATE` / `TARGET_TZ`** rules (per-line timestamp
+  preferred; otherwise mtime fallback); empty or irrelevant chatter alone does
+  not pass.
+
+**If none of these are true → STOP. Do NOT post a Jira comment. Tell the user:**
+
+> "No activity found for <TARGET_DATE>. No Jira comment was posted."
+
+**CRITICAL:** Never recycle or restate work from other days. If the only evidence
+is commits or transcripts from different dates, that is zero activity for
+`TARGET_DATE` — stop and report it.
+
+### 5. Compose the Jira comment
+
+Merge all sources into a concise progress update. Use this template:
+
+```text
+**Progress update — <TARGET_DATE> (AI generated)**
+
+- <bullet 1: what was done, with PR/commit link if applicable>
+- <bullet 2>
+- <bullet 3>
+- ...
+```
+
+Rules:
+
+- 3-5 bullets max. Each bullet is exactly **one sentence** after cleanup.
+- Lead with the most impactful work.
+- **Sanitize for Jira (all outward text):** apply the same rules to **commit
+  first lines, PR titles, and transcript-derived prose** — paraphrase or strip
+  control/markdown-surprise characters and raw HTML-ish `<...>` (except deliberate
+  link targets you author); collapse `\n`/`\\t` to spaces; cap snippet length before
+  composing bullets.
+- If a candidate bullet still has multiple sentences after paraphrasing, keep
+  only the **first** (split on sentence boundaries after `.`, `?`, or `!` once
+  whitespace is collapsed); trim trailing commas; end with exactly one terminating `.`,
+  `?`, or `!`.
+- Inline GitHub links where relevant: `[PR #123](https://github.com/owner/repo/pull/123)`.
+- Combine related commits + chat activity into a single bullet when they describe the same work.
+- Do NOT list raw commit SHAs unless there's no PR to link.
+- Do NOT include filler like "continued working on…" — be specific.
+- Only include work from **`TARGET_DATE`** (honoring **`TARGET_TZ`**). Never pull other calendar days.
+- **Only include work related to the specified repo and Jira ticket.** Do NOT
+  mix in activity from other projects, repos, or unrelated Jira tickets.
+- If no activity found for a source, omit it silently.
+
+### 6. Post to Jira
+
+- Call Jira MCP `addCommentToJiraIssue` with:
+  - `cloudId` from step 1
+  - `issueIdOrKey` — the JIRA-KEY
+  - `commentBody` — the composed comment
+  - `contentFormat: "markdown"`
+- Confirm success and show the user the posted comment text.
+
+### 7. Show output in chat
+
+Always display the final comment in chat so the user can review what was posted.
+Format it clearly with a heading like:
+
+```text
+✅ Comment posted to <JIRA-KEY>:
+<the comment body>
+```
+
+---
+
+## Failure handling
+
+- On any API error → show a **short, user-safe message** (no tokens, raw
+  headers, or stack traces).
+- If Jira MCP is unavailable or auth fails → output the comment in chat and
+  instruct the user to paste it manually.
+- If `gh api` fails → fall back to an authenticated `curl` request against
+  `https://api.github.com/...` (use the token from `gh auth token` or the
+  environment). If that also fails, skip GitHub data and compose from chat
+  transcripts only (still enforce the Step 4 gate).
+- If no transcripts found for `TARGET_DATE` → skip chat data, build comment
+  from GitHub only.
+- If both sources are empty for `TARGET_DATE` → inform the user:
+  "No activity found for <TARGET_DATE>. No Jira comment was posted."
+- If the Jira ticket key is invalid → report the error and stop.
+
+---
+
+## Example
+
+User runs: `/jira-daily-recap RHOAIENG-53408 openshift/kubeflow release-1.9`
+
+Posted comment:
+
+```text
+**Progress update — 2026-04-01 (AI generated)**
+
+- Rebased SDK PR #368 on latest upstream and resolved merge conflicts.
+- Added unit tests for the new TrainingClient checkpoint API.
+- Investigated nvcc build failure blocking RHOAIENG-56094 ([PR #705](https://github.com/openshift/kubeflow/pull/705)).
+```


### PR DESCRIPTION
# Pull Request Description

## Summary
Add a new `jira-daily-recap` skill that collects a single day's GitHub activity (commits, PRs) and Cursor chat history, then posts a concise progress comment on a Jira ticket.

## Type of Contribution
- [ ] 📝 New command
- [x] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [ ] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made
- Added `helpers/skills/jira-daily-recap/SKILL.md` — a pure-markdown skill (no scripts) that uses GitHub and Jira MCP integrations to automate daily standup comments.
- Regenerated `docs/data.json` via `make update` to include the new skill.

## Tool Details

### Skill
- **Skill name**: `jira-daily-recap`
- **Primary use case**: Automate posting daily work summaries as Jira comments by collecting GitHub commits/PRs and Cursor chat history for a target date.
- **Dependencies required**: GitHub MCP and Atlassian (Jira) MCP integrations. No external scripts, Python packages, or CLI tools required.

example comment generated by cursor and posted on jira for april 2nd 
<img width="1111" height="284" alt="image" src="https://github.com/user-attachments/assets/1696207b-b147-4427-a543-cf3bd020e34a" />


## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [ ] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [ ] Claude Code: Tested commands/skills/agents integration
- [x] Cursor AI: Tested tool integration (if applicable)
- [ ] Gemini: Created Gem in Gemini platform and verified sharing link works (if applicable)

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- No scripts — pure SKILL.md implementation
- Requires GitHub MCP (`get_me`, `list_commits`, `search_pull_requests`) and Jira MCP (`getAccessibleAtlassianResources`, `getJiraIssue`, `addCommentToJiraIssue`)
- No undocumented external dependencies

## Additional Notes
- Tracked in [RHOAIENG-56508](https://redhat.atlassian.net/browse/RHOAIENG-56508)
- Supports an optional `[date]` parameter (defaults to today, accepts `YYYY-MM-DD` or natural language) to recap a specific past day
- Includes a gate check that refuses to post if no real activity is found for the target date
- Falls back gracefully if either GitHub or Jira MCP is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily recap skill that automatically posts a work summary to Jira ticket comments, including GitHub commits, pull requests, and chat history. Supports custom dates, branches, and timezone configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-56508]: https://redhat.atlassian.net/browse/RHOAIENG-56508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ