### PR TITLE
feat: Add gh and glab CLIs to Claude image

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ You can execute Claude Code commands directly without entering an interactive se
 - `-v $(pwd):$(pwd):z` - Mounts the project at the same absolute path as on the host to reuse Claude's session data
 - `-w $(pwd)` - Sets the working directory to match the host path
 
+**CLI Authentication (GitHub and GitLab):**
+
+The container includes `gh` (GitHub CLI) and `glab` (GitLab CLI). To authenticate them inside the container, pass your
+host credentials via environment variables or volume mounts:
+
+- `-e GH_TOKEN=$(gh auth token)` - Pass your GitHub token from the host keyring
+- `-v ~/.config/glab-cli:/home/claude/.config/glab-cli:ro,z` - Mount your GitLab CLI config (contains auth token)
+
 Add this to your `~/.bashrc` for easy launching of the container:
 
 ```bash

--- a/images/claude/Containerfile
+++ b/images/claude/Containerfile
@@ -46,6 +46,38 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR="/usr/local/bin/
 RUN curl -LsSf https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar xzf - -C /usr/local/bin/ oc \
     && chmod +x /usr/local/bin/oc
 
+# Install GitHub CLI (gh)
+ARG GH_VERSION=2.89.0
+ARG GH_SHA256_AMD64=d0422caade520530e76c1c558da47daebaa8e1203d6b7ff10ad7d6faba3490d8
+ARG GH_SHA256_ARM64=9e64a623dfc242990aa5d9b3f507111149c4282f66b68eaad1dc79eeb13b9ce5
+RUN set -eu; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64)  expected="$GH_SHA256_AMD64"; dl_arch="amd64" ;; \
+      aarch64) expected="$GH_SHA256_ARM64"; dl_arch="arm64" ;; \
+      *) echo "Unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -LsSf -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${dl_arch}.tar.gz"; \
+    echo "${expected}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar xzf /tmp/gh.tar.gz --strip-components=1 -C /usr/local/; \
+    rm -f /tmp/gh.tar.gz
+
+# Install GitLab CLI (glab)
+ARG GLAB_VERSION=1.91.0
+ARG GLAB_SHA256_AMD64=31c5dd4b6f5752e4355997b3c4742c9245a7abbb60f39e58bcc4e582843e4869
+ARG GLAB_SHA256_ARM64=29fef489f40fefb615881de55d3b229fc909aaf730de700abe1f448945c5bfc2
+RUN set -eu; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64)  expected="$GLAB_SHA256_AMD64"; dl_arch="amd64" ;; \
+      aarch64) expected="$GLAB_SHA256_ARM64"; dl_arch="arm64" ;; \
+      *) echo "Unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -LsSf -o /tmp/glab.tar.gz "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_${dl_arch}.tar.gz"; \
+    echo "${expected}  /tmp/glab.tar.gz" | sha256sum -c -; \
+    tar xzf /tmp/glab.tar.gz -C /usr/local/bin/ bin/glab --strip-components=1; \
+    rm -f /tmp/glab.tar.gz
+
 # Install common Python tools
 RUN uv pip install --system --no-cache \
     pytest \


### PR DESCRIPTION
# Pull Request Description

## Summary

Install GitHub CLI (gh) and GitLab CLI (glab) in the container image with pinned versions and SHA256 checksums. Document how to pass host authentication into the container.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [x] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made

Containerfile updated to install gh/glab. Readme file updated with instructions.

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub CLI (gh) and GitLab CLI (glab) are now included in the container with support for both AMD64 and ARM64 architectures.

* **Documentation**
  * Added setup instructions for authenticating with GitHub and GitLab inside the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->