### PR TITLE
Add CI streaming mode to Claude Code container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: pip install pytest
+
+    - name: Run tests
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,16 @@ update: ## Update Claude settings and website data
 		echo "ruff not found, skipping Python formatting. Install with: pip install ruff"; \
 	fi
 
+.PHONY: test
+test: ## Run tests
+	@echo "Running tests..."
+	@if command -v pytest >/dev/null 2>&1; then \
+		pytest images/claude/tests/ -v; \
+	else \
+		echo "pytest not found. Install with: pip install pytest"; \
+		exit 1; \
+	fi
+
 .PHONY: build
 build: build-claude build-cursor ## Build all container images
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,41 @@ claude-container() {
 }
 ```
 
+### CI Streaming Mode
+
+When running Claude Code non-interactively in CI pipelines, set `CLAUDE_CI_STREAM=1` to get
+human-readable streaming output instead of raw JSON. The container automatically adds the
+required flags and pipes output through a built-in parser that renders thinking blocks, tool
+use, token stats, and errors as readable log lines.
+
+```bash
+podman run --rm \
+  --userns=keep-id:uid=1000,gid=1000 \
+  -e CLAUDE_CODE_USE_VERTEX=1 \
+  -e CLOUD_ML_REGION=your-ml-region \
+  -e ANTHROPIC_VERTEX_PROJECT_ID=your-project-id \
+  -e DISABLE_AUTOUPDATER=1 \
+  -e CLAUDE_CI_STREAM=1 \
+  -e CLAUDE_CI_LOG_FILE=/workspace/.claude-output.txt \
+  -v ~/.config/gcloud:/home/claude/.config/gcloud:ro,z \
+  -v $(pwd):/workspace:z \
+  -w /workspace \
+  ghcr.io/opendatahub-io/ai-helpers:latest \
+  --permission-mode bypassPermissions \
+  -p "Fix the bug described in ISSUE-123"
+```
+
+**CI Streaming Environment Variables:**
+
+| Variable | Default | Description |
+|---|---|---|
+| `CLAUDE_CI_STREAM` | _(unset)_ | Set to `1` to enable streaming mode |
+| `CLAUDE_CI_LOG_FILE` | _(unset)_ | Path (inside the container) to write a plain-text log without ANSI codes |
+| `CLAUDE_CI_WRAP` | `0` | Word-wrap output at N columns (0 = no wrapping) |
+| `NO_COLOR` | _(unset)_ | Set to `1` to disable ANSI color codes in output |
+
+Without `CLAUDE_CI_STREAM`, the container behaves identically to running `claude` directly.
+
 ### Running Cursor Agent CLI in a Container
 
 A container image is also available with the Cursor Agent CLI and all development tools pre-installed:

--- a/images/claude/Containerfile
+++ b/images/claude/Containerfile
@@ -81,5 +81,7 @@ RUN cp /home/claude/.local/bin/claude /usr/bin/claude && \
     chmod +x /usr/bin/claude
 USER claude
 
-# Set Claude Code as the default command
-ENTRYPOINT ["claude"]
+# Set entrypoint wrapper as the default command.  The wrapper passes
+# through to `claude` directly unless CLAUDE_CI_STREAM=1 is set, in
+# which case it enables human-readable streaming output for CI.
+ENTRYPOINT ["/opt/ai-helpers/images/claude/claude-ci-entrypoint.sh"]

--- a/images/claude/claude-ci-entrypoint.sh
+++ b/images/claude/claude-ci-entrypoint.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Entrypoint wrapper for the Claude Code container image.
+#
+# By default, passes through to `claude` directly (identical to the
+# previous ENTRYPOINT ["claude"]).
+#
+# When CLAUDE_CI_STREAM=1 is set, enables human-readable streaming
+# output suitable for CI pipelines.  The wrapper automatically adds
+# the required stream-json flags and pipes Claude's output through
+# a parser that renders thinking, tool use, token stats, and errors
+# as readable CI log lines.
+#
+# Environment variables (CI streaming mode only):
+#   CLAUDE_CI_STREAM=1       Enable streaming mode
+#   CLAUDE_CI_LOG_FILE       Write plain-text log (no ANSI) to this path
+#   CLAUDE_CI_WRAP           Word-wrap output at N columns (0 = off)
+#   NO_COLOR=1               Disable ANSI color codes
+
+set -euo pipefail
+
+# --- Non-streaming mode: transparent passthrough ---
+if [[ "${CLAUDE_CI_STREAM:-}" != "1" ]]; then
+    exec claude "$@"
+fi
+
+# --- CI streaming mode ---
+
+# Build stream-claude.py arguments from environment.
+stream_args=()
+[[ -n "${CLAUDE_CI_LOG_FILE:-}" ]] && stream_args+=(--log-file "$CLAUDE_CI_LOG_FILE")
+[[ -n "${CLAUDE_CI_WRAP:-}" ]]     && stream_args+=(--wrap "$CLAUDE_CI_WRAP")
+[[ "${NO_COLOR:-}" == "1" ]]       && stream_args+=(--no-color)
+
+# Create a FIFO so we can run claude and the stream parser as
+# independent processes — this lets us track exit codes separately.
+fifo=$(mktemp -u).fifo
+mkfifo "$fifo"
+trap 'rm -f "$fifo"' EXIT
+
+# Run claude with stream-json output directed to the FIFO.
+claude \
+    --output-format stream-json \
+    --include-partial-messages \
+    --include-hook-events \
+    --verbose \
+    "$@" > "$fifo" &
+claude_pid=$!
+
+# Run the stream parser in the background.  Both children must be
+# backgrounded so that bash can respond to signals — bash defers
+# trap handlers while a foreground command is running, but processes
+# them immediately when blocked on `wait`.
+python3 -u /opt/ai-helpers/images/claude/stream-claude.py "${stream_args[@]}" < "$fifo" &
+stream_pid=$!
+
+# Forward signals to children.  As PID 1 in a container, this
+# process does not get default signal handlers — SIGTERM must be
+# explicitly caught and forwarded.
+# shellcheck disable=SC2317  # invoked indirectly via trap
+_on_signal() {
+    kill "$claude_pid" "$stream_pid" 2>/dev/null || true
+}
+trap '_on_signal' TERM INT
+
+# Wait for the stream parser to finish.  It exits when it sees a
+# "result" event (success, rc=0) or EOF without one (failure, rc=1).
+wait "$stream_pid" 2>/dev/null && stream_rc=0 || stream_rc=$?
+
+# Stream parser is done — clean up claude.
+kill "$claude_pid" 2>/dev/null || true
+wait "$claude_pid" 2>/dev/null && claude_rc=0 || claude_rc=$?
+
+# Parser failure should still fail the container immediately.
+if [[ "$stream_rc" -ne 0 ]]; then
+    exit "$stream_rc"
+fi
+
+# Treat normal exit and intentional SIGTERM (143 = 128+15) as success;
+# propagate anything else (e.g. claude exiting 1 or 2).
+if [[ "$claude_rc" -eq 0 || "$claude_rc" -eq 143 ]]; then
+    exit 0
+fi
+
+exit "$claude_rc"

--- a/images/claude/stream-claude.py
+++ b/images/claude/stream-claude.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Parse Claude Code stream-json output into a human-readable CI log."""
+
+import argparse
+import atexit
+import json
+import re
+import sys
+import time
+
+parser = argparse.ArgumentParser(description="Parse Claude Code stream-json output")
+parser.add_argument(
+    "--wrap",
+    type=int,
+    default=0,
+    metavar="COLS",
+    help="Word-wrap output at COLS columns (0 = no wrapping)",
+)
+parser.add_argument(
+    "--no-color",
+    action="store_true",
+    help="Disable ANSI color codes in output",
+)
+parser.add_argument(
+    "--log-file",
+    type=str,
+    default="",
+    help="Write plain-text (no ANSI) output to this file",
+)
+args = parser.parse_args()
+
+# ANSI colors (GitLab CI supports these)
+if args.no_color:
+    THINK_COLOR = TOOL_COLOR = CLAUDE_COLOR = RED = YELLOW = RESET = ""
+else:
+    THINK_COLOR = "\033[3;31m"  # italic red
+    TOOL_COLOR = "\033[1;90m"  # bold gray
+    CLAUDE_COLOR = ""  # normal
+    RED = "\033[31m"
+    YELLOW = "\033[33m"
+    RESET = "\033[0m"
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+
+def _safe(text):
+    """Strip ANSI escapes, control characters, and CI workflow commands."""
+    text = str(text)
+    text = _ANSI_RE.sub("", text)
+    text = _CONTROL_RE.sub("", text)
+    if text.startswith("::"):
+        text = f" {text}"
+    return text
+
+
+log_file = open(args.log_file, "w") if args.log_file else None
+if log_file:
+    atexit.register(log_file.close)
+
+active_block = None  # "text", "thinking", or None
+_saw_result = False
+tool_name = None
+tool_json_parts = []
+_line_buf = ""
+_total_input_tokens = 0
+_total_output_tokens = 0
+_total_cache_read = 0
+_total_cache_write = 0
+_last_emitted_total = 0
+_last_emitted_time = 0.0
+
+
+def _log(text):
+    """Write plain text to the log file (if configured)."""
+    if log_file:
+        log_file.write(text)
+        log_file.flush()
+
+
+def emit(text):
+    """Buffer text and flush complete lines."""
+    global _line_buf
+    _line_buf += text
+    while "\n" in _line_buf:
+        line, _line_buf = _line_buf.split("\n", 1)
+        if args.wrap and len(line) > args.wrap:
+            # Word-boundary wrap
+            wrapped = ""
+            col = 0
+            for word in line.split(" "):
+                if col + len(word) > args.wrap and col > 0:
+                    wrapped += "\n"
+                    col = 0
+                if col > 0:
+                    wrapped += " "
+                    col += 1
+                wrapped += word
+                col += len(word)
+            print(wrapped, flush=True)
+            _log(wrapped + "\n")
+        else:
+            print(line, flush=True)
+            _log(line + "\n")
+
+
+def flush_emit():
+    """Flush any remaining buffered text."""
+    global _line_buf
+    if _line_buf:
+        print(_line_buf, flush=True)
+        _log(_line_buf + "\n")
+        _line_buf = ""
+
+
+def _print(text, end="\n"):
+    """Print colored text to stdout and plain text to the log file."""
+    print(text, end=end, flush=True)
+    if log_file:
+        plain = _ANSI_RE.sub("", text)
+        log_file.write(plain + end)
+        log_file.flush()
+
+
+def _format_tool(name, params):
+    """Return a compact one-line summary for a tool call."""
+    if name == "Bash":
+        cmd = params.get("command", "")
+        desc = params.get("description", "")
+        return f"$ {cmd}" + (f"  # {desc}" if desc else "")
+    if name == "Read":
+        path = params.get("file_path", "")
+        parts = [path]
+        if "offset" in params:
+            parts.append(f"L{params['offset']}")
+        if "limit" in params:
+            parts.append(f"+{params['limit']}")
+        return " ".join(parts)
+    if name == "Write":
+        return params.get("file_path", "")
+    if name == "Edit":
+        path = params.get("file_path", "")
+        old = params.get("old_string", "")
+        preview = old.split("\n")[0][:60]
+        if len(old) > len(preview):
+            preview += "..."
+        return f"{path}: {preview}"
+    if name == "Glob":
+        pattern = params.get("pattern", "")
+        path = params.get("path", ".")
+        return f"{pattern} in {path}"
+    if name == "Grep":
+        pattern = params.get("pattern", "")
+        path = params.get("path", ".")
+        return f"/{pattern}/ in {path}"
+    if name == "Agent":
+        desc = params.get("description", "")
+        agent_type = params.get("subagent_type", "")
+        return f"[{agent_type}] {desc}" if agent_type else desc
+    if name == "Skill":
+        skill = params.get("skill", "")
+        skill_args = params.get("args", "")
+        return f"/{skill} {skill_args}".strip()
+    if name == "TaskGet":
+        return params.get("task_id", "")
+    # Generic fallback: key=value pairs on one line
+    return ", ".join(f"{k}={v}" for k, v in params.items())
+
+
+def end_block():
+    global active_block, tool_name, tool_json_parts
+    if active_block in ("text", "thinking"):
+        flush_emit()
+        sys.stdout.write(RESET + "\n")
+        _log("\n")
+        active_block = None
+    if tool_name:
+        tool_json = "".join(tool_json_parts)
+        try:
+            parsed = json.loads(tool_json)
+        except (json.JSONDecodeError, ValueError):
+            parsed = None
+
+        summary = _safe(_format_tool(tool_name, parsed)) if parsed else None
+
+        if summary:
+            icon = "\U0001f916" if tool_name == "Agent" else "\U0001f527"
+            _print(f"  {TOOL_COLOR}{icon} {tool_name} {summary}{RESET}")
+        else:
+            _print(f"  {TOOL_COLOR}\U0001f527 {tool_name}{RESET}")
+            if parsed:
+                formatted = json.dumps(parsed, indent=2)
+                for fmtline in formatted.split("\n"):
+                    _print(f"    {TOOL_COLOR}{fmtline}{RESET}")
+        tool_name = None
+        tool_json_parts = []
+
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    try:
+        msg = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        continue
+
+    msg_type = msg.get("type")
+
+    # System events (retries, etc.)
+    if msg_type == "system":
+        subtype = msg.get("subtype", "")
+        if subtype == "api_retry":
+            attempt = msg.get("attempt", "?")
+            max_retries = msg.get("max_retries", "?")
+            delay = msg.get("retry_delay_ms", "?")
+            error = _safe(msg.get("error", "unknown"))
+            _print(
+                f"{YELLOW}\U0001f504 Retry {attempt}/{max_retries}{RESET} "
+                f"{error} \u2014 retrying in {delay}ms",
+            )
+        elif subtype == "compact_boundary":
+            meta = msg.get("compact_metadata", {})
+            trigger = meta.get("trigger", "?")
+            pre_tokens = meta.get("pre_tokens", "?")
+            _print(
+                f"{YELLOW}\U0001f4e6 Context compacted ({trigger}) pre_tokens={pre_tokens}{RESET}",
+            )
+        elif subtype == "hook_started":
+            hook_name = _safe(msg.get("hook_name", "?"))
+            _print(
+                f"{YELLOW}\U0001fa9d Hook started: {hook_name}{RESET}",
+            )
+        elif subtype == "hook_response":
+            hook_name = _safe(msg.get("hook_name", "?"))
+            exit_code = msg.get("exit_code", "?")
+            outcome = _safe(msg.get("outcome", "?"))
+            stdout = _safe(msg.get("stdout", "").strip())
+            stderr = _safe(msg.get("stderr", "").strip())
+            _print(
+                f"{YELLOW}\U0001fa9d Hook {hook_name}: {outcome} (rc={exit_code}){RESET}",
+            )
+            if stdout:
+                for out_line in stdout.split("\n"):
+                    _print(f"  {YELLOW}{out_line}{RESET}")
+            if stderr:
+                for err_line in stderr.split("\n"):
+                    _print(f"  {RED}{err_line}{RESET}")
+        continue
+
+    if msg_type == "result":
+        _saw_result = True
+        end_block()
+        break
+
+    if msg_type != "stream_event":
+        continue
+
+    event = msg.get("event", {})
+    event_type = event.get("type")
+
+    # Content block start
+    if event_type == "content_block_start":
+        block = event.get("content_block", {})
+        block_type = block.get("type")
+        if block_type == "text":
+            print(f"{CLAUDE_COLOR}\U0001f4ac Claude ", end="", flush=True)
+            _log("\U0001f4ac Claude ")
+            active_block = "text"
+        elif block_type == "thinking":
+            print(f"{THINK_COLOR}\U0001f9e0 Thinking ", end="", flush=True)
+            _log("\U0001f9e0 Thinking ")
+            active_block = "thinking"
+        elif block_type in ("tool_use", "server_tool_use"):
+            tool_name = block.get("name", "unknown")
+            tool_json_parts = []
+
+    # Content block deltas
+    elif event_type == "content_block_delta":
+        delta = event.get("delta", {})
+        delta_type = delta.get("type")
+        if delta_type == "text_delta":
+            emit(_safe(delta.get("text", "")))
+        elif delta_type == "thinking_delta":
+            emit(_safe(delta.get("thinking", "")))
+        elif delta_type == "input_json_delta":
+            tool_json_parts.append(delta.get("partial_json", ""))
+
+    # Content block stop
+    elif event_type == "content_block_stop":
+        end_block()
+
+    # Message start -- carries cumulative input token counts
+    elif event_type == "message_start":
+        usage = event.get("message", {}).get("usage", {})
+        _total_input_tokens = usage.get("input_tokens", 0)
+        _total_cache_read = usage.get("cache_read_input_tokens", 0)
+        _total_cache_write = usage.get("cache_creation_input_tokens", 0)
+
+    # Message delta -- carries cumulative output token count
+    elif event_type == "message_delta":
+        usage = event.get("usage", {})
+        out = usage.get("output_tokens", 0)
+        if out > 0:
+            _total_output_tokens = out
+            total = (
+                _total_input_tokens + _total_output_tokens + _total_cache_read + _total_cache_write
+            )
+            # Emit every 5k tokens to avoid noise
+            if total - _last_emitted_total >= 5_000 or _last_emitted_total == 0:
+                now = time.monotonic()
+                rate = 0.0
+                if _last_emitted_time > 0:
+                    dt = now - _last_emitted_time
+                    dv = total - _last_emitted_total
+                    if dt > 0:
+                        rate = dv / dt
+                rate_str = f" rate={rate:.0f}/s" if rate > 0 else ""
+                _last_emitted_total = total
+                _last_emitted_time = now
+                _print(
+                    f"{TOOL_COLOR}  \U0001f4ca TOKENS in={_total_input_tokens}"
+                    f" out={_total_output_tokens}"
+                    f" cache_r={_total_cache_read}"
+                    f" cache_w={_total_cache_write}"
+                    f" total={total}{rate_str}{RESET}",
+                )
+
+    # Errors
+    elif event_type == "error":
+        error = event.get("error", {})
+        error_type = _safe(error.get("type", "unknown"))
+        error_msg = _safe(error.get("message", ""))
+        _print(
+            f"{RED}\u274c Error: {error_type}: {error_msg}{RESET}",
+        )
+
+print()
+sys.exit(0 if _saw_result else 1)

--- a/images/claude/tests/test_stream_claude.py
+++ b/images/claude/tests/test_stream_claude.py
@@ -1,0 +1,303 @@
+"""Smoke tests for stream-claude.py.
+
+Each test feeds a known JSON fixture into the parser via subprocess and
+checks that the output contains the expected human-readable lines.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "stream-claude.py")
+
+
+def _run(events, extra_args=None):
+    """Feed *events* (list of dicts) into stream-claude.py and return (stdout, returncode)."""
+    input_data = "\n".join(json.dumps(e) for e in events) + "\n"
+    cmd = [sys.executable, "-u", SCRIPT, "--no-color"] + (extra_args or [])
+    proc = subprocess.run(
+        cmd,
+        input=input_data,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.stdout, proc.returncode
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — minimal JSON events that exercise each code path
+# ---------------------------------------------------------------------------
+
+
+def _text_block(text):
+    """Return start / delta / stop events for a text content block."""
+    return [
+        {
+            "type": "stream_event",
+            "event": {"type": "content_block_start", "content_block": {"type": "text"}},
+        },
+        {
+            "type": "stream_event",
+            "event": {"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}},
+        },
+        {"type": "stream_event", "event": {"type": "content_block_stop"}},
+    ]
+
+
+def _thinking_block(text):
+    return [
+        {
+            "type": "stream_event",
+            "event": {"type": "content_block_start", "content_block": {"type": "thinking"}},
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "thinking_delta", "thinking": text},
+            },
+        },
+        {"type": "stream_event", "event": {"type": "content_block_stop"}},
+    ]
+
+
+def _tool_block(name, params):
+    partial = json.dumps(params)
+    return [
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "content_block": {"type": "tool_use", "name": name},
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "input_json_delta", "partial_json": partial},
+            },
+        },
+        {"type": "stream_event", "event": {"type": "content_block_stop"}},
+    ]
+
+
+RESULT_EVENT = {"type": "result"}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestExitCode:
+    def test_exits_0_on_result(self):
+        events = _text_block("hello\n") + [RESULT_EVENT]
+        _, rc = _run(events)
+        assert rc == 0
+
+    def test_exits_1_on_eof_without_result(self):
+        events = _text_block("hello\n")
+        _, rc = _run(events)
+        assert rc == 1
+
+
+class TestTextOutput:
+    def test_text_block_rendered(self):
+        events = _text_block("Hello world\n") + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "Claude" in out
+        assert "Hello world" in out
+
+    def test_thinking_block_rendered(self):
+        events = _thinking_block("Let me think...\n") + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "Thinking" in out
+        assert "Let me think..." in out
+
+
+class TestToolFormatting:
+    def test_bash_tool(self):
+        events = _tool_block("Bash", {"command": "ls -la", "description": "List files"}) + [
+            RESULT_EVENT
+        ]
+        out, _ = _run(events)
+        assert "$ ls -la" in out
+        assert "# List files" in out
+
+    def test_read_tool(self):
+        events = _tool_block("Read", {"file_path": "/tmp/foo.py"}) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "/tmp/foo.py" in out
+
+    def test_edit_tool(self):
+        events = _tool_block(
+            "Edit", {"file_path": "/tmp/foo.py", "old_string": "old", "new_string": "new"}
+        ) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "/tmp/foo.py" in out
+        assert "old" in out
+
+    def test_grep_tool(self):
+        events = _tool_block("Grep", {"pattern": "TODO", "path": "src/"}) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "/TODO/" in out
+        assert "src/" in out
+
+    def test_glob_tool(self):
+        events = _tool_block("Glob", {"pattern": "**/*.py", "path": "."}) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "**/*.py" in out
+
+    def test_write_tool(self):
+        events = _tool_block("Write", {"file_path": "/tmp/new.py"}) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "/tmp/new.py" in out
+
+    def test_agent_tool(self):
+        events = _tool_block(
+            "Agent", {"description": "Search codebase", "subagent_type": "Explore"}
+        ) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "[Explore]" in out
+        assert "Search codebase" in out
+
+    def test_skill_tool(self):
+        events = _tool_block("Skill", {"skill": "commit", "args": "-m 'fix'"}) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "/commit" in out
+
+    def test_unknown_tool_shows_params(self):
+        events = _tool_block("CustomTool", {"key": "value"}) + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "CustomTool" in out
+        assert "key=value" in out
+
+
+class TestSystemEvents:
+    def test_api_retry(self):
+        events = (
+            [
+                {
+                    "type": "system",
+                    "subtype": "api_retry",
+                    "attempt": 1,
+                    "max_retries": 3,
+                    "retry_delay_ms": 1000,
+                    "error": "rate_limit",
+                },
+            ]
+            + _text_block("ok\n")
+            + [RESULT_EVENT]
+        )
+        out, _ = _run(events)
+        assert "Retry 1/3" in out
+        assert "rate_limit" in out
+
+    def test_compact_boundary(self):
+        events = [
+            {
+                "type": "system",
+                "subtype": "compact_boundary",
+                "compact_metadata": {"trigger": "auto", "pre_tokens": 50000},
+            },
+        ] + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "compacted" in out
+        assert "auto" in out
+
+    def test_hook_events(self):
+        events = [
+            {"type": "system", "subtype": "hook_started", "hook_name": "pre-commit"},
+            {
+                "type": "system",
+                "subtype": "hook_response",
+                "hook_name": "pre-commit",
+                "exit_code": 0,
+                "outcome": "success",
+                "stdout": "ok",
+                "stderr": "",
+            },
+        ] + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "Hook started: pre-commit" in out
+        assert "success" in out
+
+
+class TestErrorEvent:
+    def test_error_rendered(self):
+        events = [
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": "error",
+                    "error": {"type": "overloaded", "message": "server busy"},
+                },
+            },
+        ]
+        out, _ = _run(events)
+        assert "overloaded" in out
+        assert "server busy" in out
+
+
+class TestLogFile:
+    def test_log_file_written_without_ansi(self):
+        events = _text_block("logged output\n") + [RESULT_EVENT]
+        with tempfile.NamedTemporaryFile(mode="r", suffix=".log", delete=False) as f:
+            log_path = f.name
+        try:
+            _run(events, extra_args=["--log-file", log_path])
+            with open(log_path) as f:
+                content = f.read()
+            assert "logged output" in content
+            assert "\033[" not in content
+        finally:
+            os.unlink(log_path)
+
+
+class TestMalformedInput:
+    def test_invalid_json_skipped(self):
+        events = _text_block("valid\n") + [RESULT_EVENT]
+        # Inject garbage between valid events
+        input_lines = []
+        for e in events[:1]:
+            input_lines.append(json.dumps(e))
+        input_lines.append("this is not json {{{")
+        for e in events[1:]:
+            input_lines.append(json.dumps(e))
+        input_data = "\n".join(input_lines) + "\n"
+
+        cmd = [sys.executable, "-u", SCRIPT, "--no-color"]
+        proc = subprocess.run(cmd, input=input_data, capture_output=True, text=True, timeout=10)
+        assert proc.returncode == 0
+        assert "valid" in proc.stdout
+
+
+class TestTokenStats:
+    def test_token_stats_emitted(self):
+        events = [
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": "message_start",
+                    "message": {
+                        "usage": {
+                            "input_tokens": 5000,
+                            "cache_read_input_tokens": 1000,
+                            "cache_creation_input_tokens": 500,
+                        }
+                    },
+                },
+            },
+            {
+                "type": "stream_event",
+                "event": {"type": "message_delta", "usage": {"output_tokens": 200}},
+            },
+        ] + [RESULT_EVENT]
+        out, _ = _run(events)
+        assert "TOKENS" in out
+        assert "in=5000" in out
+        assert "out=200" in out


### PR DESCRIPTION
# Pull Request Description

## Summary

Replace the bare ENTRYPOINT ["claude"] with a wrapper script that activates human-readable streaming output when CLAUDE_CI_STREAM=1 is set. Without the env var, the wrapper does `exec claude` as before.

In streaming mode, the wrapper automatically adds --output-format stream-json flags and pipes output through a built-in parser (stream-claude.py) that renders thinking blocks, tool use, token stats, retries, and errors as readable CI log lines. This eliminates the need for each consumer of the image to ship their own streaming parser.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [x] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made

Added streaming script, added tests, added wrapper into container image, and docs on using new env vars.

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

Tested locally:
```
● Bash(podman run -it --rm 
       [...truncated...]
        localhost/ai-helpers:latest \
        --permission-mode bypassPermissions \
        -p "Compute 2+2. Reply with just the number." 2>&1)
  ⎿  time="2026-04-13T21:17:40-04:00" level=warning msg="The input device is not a TTY. The --tty and --interactive flags might not work properly"
     💬 Claude 4
       📊 TOKENS in=3 out=5 cache_r=0 cache_w=16270 total=16278
```

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI streaming mode that produces human-readable logs instead of raw JSON; enable via CLAUDE_CI_STREAM=1 for non-interactive CI runs.

* **Documentation**
  * Documented CI streaming mode, supported environment variables (CI stream, log file, wrap, no-color) and usage examples.

* **Tests**
  * Added comprehensive smoke tests validating streaming output, token stats, error handling and log-file behavior.

* **Chores**
  * Added a repository test target and an automated workflow to run tests on push/pull requests to main.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->