### PR TITLE
Add jira-status-summary skill to AIPCC category

### DIFF
--- a/categories.yaml
+++ b/categories.yaml
@@ -3,6 +3,7 @@ AIPCC:
   - commit-message-assistant
   - aipcc-adr-assistant
   - jira-aipcc-create
+  - jira-status-summary
 
 PyTorch:
   - torchtalk-analyzer

--- a/docs/data.json
+++ b/docs/data.json
@@ -133,6 +133,14 @@
         "allowed_tools": "Bash, AskUserQuestion"
       },
       {
+        "name": "jira-status-summary",
+        "description": "Update the Status Summary field on AIPCC Feature and Initiative tickets. Fetches child ticket activity via the jira-activity skill, generates a health-color summary (green/yellow/red), and writes it to Jira. Use when asked to update the status summary for a Jira ticket.\n",
+        "category": "aipcc",
+        "file_path": "helpers/skills/jira-status-summary/SKILL.md",
+        "id": "jira-status-summary",
+        "allowed_tools": "Bash"
+      },
+      {
         "name": "jira-upload-chat-log",
         "description": "Export and upload the current chat conversation as a markdown file attachment to a JIRA ticket for later review and documentation.",
         "category": "general",

--- a/helpers/skills/jira-status-summary/SKILL.md
+++ b/helpers/skills/jira-status-summary/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: jira-status-summary
+description: >
+  Update the Status Summary field on AIPCC Feature and Initiative tickets.
+  Fetches child ticket activity via the jira-activity skill, generates a
+  health-color summary (green/yellow/red), and writes it to Jira.
+  Use when asked to update the status summary for a Jira ticket.
+allowed-tools: Bash
+user-invocable: true
+---
+
+# Jira Status Summary
+
+Update the "Status Summary" custom field on an AIPCC Feature or Initiative
+ticket with an AI-generated health-color summary.
+
+## Prerequisites
+
+- Python 3 and `uv` must be installed and available in PATH
+- `JIRA_API_TOKEN` environment variable must be set with a valid API token for https://redhat.atlassian.net
+- `JIRA_EMAIL` environment variable must be set with the email address associated with your Atlassian account
+- The `jira-activity` skill must be installed (provides child ticket activity data)
+
+## Usage
+
+This skill takes a single ticket key as input and produces a formatted status
+summary written to the Jira "Status Summary" custom field.
+
+## Implementation
+
+### Step 1: Determine the Ticket Key
+
+1. If a ticket key is provided by the user, use it
+2. Otherwise, search the conversation history for JIRA ticket references (e.g., "AIPCC-1234")
+3. If no ticket is found in context, ask the user: "Which ticket should I update the Status Summary for? (e.g., AIPCC-1234)"
+
+### Step 2: Fetch Child Ticket Activity
+
+Run the fetch script from the `jira-activity` skill to gather activity data
+for the ticket and its entire child hierarchy. Execute the script directly
+(not via `python`) relative to the jira-activity skill directory:
+
+```bash
+./scripts/fetch_jira_activity.py <TICKET-KEY> --days 30
+```
+
+The script outputs JSON to stdout containing the complete hierarchy of issues
+with levels, statuses, assignees, recent comments, and changelog entries.
+
+Capture the full JSON output for analysis in the next step.
+
+### Step 3: Analyze Activity and Generate Summary
+
+Analyze the JSON output from Step 2 and determine:
+
+#### Health Color
+
+Assign exactly one of these colors:
+
+- **green**: Work is progressing normally. Child tickets are moving through
+  statuses, no significant blockers.
+- **yellow**: Some concerns. Delays on key items, blocked tickets, slowing
+  momentum, approaching deadline risks.
+- **red**: Significant blockers. Most child tickets stalled, at risk of
+  missing the due date, or critical path items are stuck.
+
+#### Summary Text
+
+Write a brief summary (2-4 sentences) for leadership consumption covering:
+
+- Overall progress and momentum
+- Key completions or milestones since last update
+- Active risks, blockers, or dependencies (if any)
+- What is coming next
+
+The summary must be self-contained and understandable without reading the
+child tickets. Do NOT include the date, color name, emoji, or disclaimer
+in the summary text -- those are added automatically by the script.
+
+### Step 4: Write to Jira
+
+Run the write script located at `scripts/write_status_summary.py` relative
+to this skill. Execute it directly (not via `python`) to invoke uv via the
+shebang:
+
+```bash
+./scripts/write_status_summary.py <TICKET-KEY> --color <color> --summary "<summary text>"
+```
+
+The script will:
+- Format the status string with today's date, color label, emoji, and AI disclaimer
+- Convert to Atlassian Document Format (ADF)
+- Write the value to the "Status Summary" custom field on the ticket
+- Print a success or error message
+
+### Step 5: Report Result
+
+If the write succeeds, inform the user:
+
+> Updated the Status Summary on <TICKET-KEY> with health color: <Color>.
+> View: https://redhat.atlassian.net/browse/<TICKET-KEY>
+
+If the write fails, display the error message and suggest checking credentials
+and ticket permissions.
+
+## Error Handling
+
+- **Missing JIRA_API_TOKEN or JIRA_EMAIL**: Inform the user how to set them
+- **jira-activity skill not found**: Tell the user the skill must be installed
+- **Invalid Ticket Key**: Verify the ticket exists and is accessible
+- **Permission Denied**: Check that the API token has permission to edit the ticket
+- **Script Errors**: Display the stderr output from the script
+
+## Examples
+
+### Basic Usage
+```text
+User: Update the status summary for AIPCC-12345
+Assistant: [Fetches activity, analyzes, writes summary to Jira]
+```
+
+### Context Detection
+```text
+User: We're reviewing AIPCC-12345. Can you update the status?
+Assistant: [Detects ticket from context, fetches activity, writes summary]
+```

--- a/helpers/skills/jira-status-summary/scripts/write_status_summary.py
+++ b/helpers/skills/jira-status-summary/scripts/write_status_summary.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = [
+#     "requests>=2.28.0",
+# ]
+# ///
+"""
+Write a formatted Status Summary to a Jira ticket's custom field.
+
+Builds a date-stamped status string with health color and AI disclaimer,
+converts it to Atlassian Document Format (ADF), and writes it to the
+"Status Summary" custom field via the Jira REST API v3.
+
+Authentication:
+  JIRA_API_TOKEN environment variable must be set with a valid API token
+  JIRA_EMAIL (or JIRA_USER) environment variable must be set
+
+Usage:
+  write_status_summary.py <ticket-key> --color green --summary "Summary text."
+
+Examples:
+  write_status_summary.py AIPCC-12345 --color green --summary "On track. Two epics completed."
+  write_status_summary.py AIPCC-12345 --color yellow --summary "Some delays on Epic X."
+  write_status_summary.py AIPCC-12345 --color red --summary "Blocked on dependency Y."
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+JIRA_URL = "https://redhat.atlassian.net"
+API_VERSION = "3"
+API_TIMEOUT = int(os.getenv("JIRA_API_TIMEOUT", "30"))
+STATUS_FIELD_NAME = "Status Summary"
+
+COLOR_MAP = {
+    "green": ("Green", "\U0001f7e2"),
+    "yellow": ("Yellow", "\U0001f7e1"),
+    "red": ("Red", "\U0001f534"),
+}
+
+
+def api_url(path: str) -> str:
+    return f"{JIRA_URL}/rest/api/{API_VERSION}/{path}"
+
+
+def get_auth() -> tuple[str, str]:
+    email = os.getenv("JIRA_EMAIL") or os.getenv("JIRA_USER")
+    token = os.getenv("JIRA_API_TOKEN")
+    if not email:
+        print("ERROR: JIRA_EMAIL (or JIRA_USER) environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+    if not token:
+        print("ERROR: JIRA_API_TOKEN environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+    return (email, token)
+
+
+def build_status_text(color: str, summary: str) -> str:
+    color_label, emoji = COLOR_MAP[color]
+    date_str = datetime.now(timezone.utc).strftime("%d/%b/%Y")
+    return (
+        f"{date_str} {color_label} {emoji}\n"
+        f"\u26a0\ufe0f AI-generated summary \u2014 please review before the Program Call.\n"
+        f"\n"
+        f"{summary}"
+    )
+
+
+def text_to_adf(text: str) -> dict:
+    paragraphs = []
+    for line in text.split("\n"):
+        if line.strip():
+            paragraphs.append({"type": "paragraph", "content": [{"type": "text", "text": line}]})
+        else:
+            paragraphs.append({"type": "paragraph", "content": []})
+    return {"version": 1, "type": "doc", "content": paragraphs}
+
+
+def find_field_id(field_name: str, auth: tuple[str, str]) -> str:
+    resp = requests.get(
+        api_url("field"),
+        headers={"Content-Type": "application/json"},
+        auth=auth,
+        timeout=API_TIMEOUT,
+    )
+    if resp.status_code != 200:
+        print(f"ERROR: HTTP {resp.status_code} fetching fields: {resp.text}", file=sys.stderr)
+        sys.exit(1)
+    for field in resp.json():
+        if field.get("name") == field_name:
+            return field["id"]
+    print(f"ERROR: Field '{field_name}' not found in Jira metadata.", file=sys.stderr)
+    sys.exit(1)
+
+
+def write_field(ticket: str, field_id: str, adf_value: dict, auth: tuple[str, str]) -> None:
+    resp = requests.put(
+        api_url(f"issue/{ticket}"),
+        headers={"Content-Type": "application/json"},
+        json={"fields": {field_id: adf_value}},
+        auth=auth,
+        timeout=API_TIMEOUT,
+    )
+    if resp.status_code == 204:
+        print(f"Updated '{STATUS_FIELD_NAME}' on {ticket}")
+    else:
+        print(f"ERROR: HTTP {resp.status_code} updating {ticket}: {resp.text}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("ticket_key", help="Jira ticket key (e.g. AIPCC-12345)")
+    parser.add_argument(
+        "--color",
+        required=True,
+        choices=["green", "yellow", "red"],
+        help="Health color: green, yellow, or red",
+    )
+    parser.add_argument(
+        "--summary",
+        required=True,
+        help="AI-generated summary text (2-4 sentences)",
+    )
+    args = parser.parse_args()
+
+    auth = get_auth()
+    status_text = build_status_text(args.color, args.summary)
+    adf_value = text_to_adf(status_text)
+    field_id = find_field_id(STATUS_FIELD_NAME, auth)
+    write_field(args.ticket_key, field_id, adf_value, auth)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New `jira-status-summary` skill that updates the "Status Summary" custom field on AIPCC Feature and Initiative tickets
- Self-contained Python script (`write_status_summary.py`) formats a health-color status string (green/yellow/red) with date, emoji, and AI disclaimer, converts to ADF, and writes to Jira via REST API v3
- SKILL.md defines a 5-step AI agent workflow: determine ticket key, fetch child activity via `jira-activity` skill, analyze and generate summary, write to Jira, report result
- Registered under AIPCC category in `categories.yaml`

## Test plan
- [ ] Verify `make lint` passes
- [ ] Verify `./helpers/skills/jira-status-summary/scripts/write_status_summary.py --help` shows correct usage
- [ ] Verify script rejects invalid color: `--color purple` returns error
- [ ] Verify script fails gracefully without `JIRA_EMAIL`/`JIRA_API_TOKEN`
- [ ] Test end-to-end against a real AIPCC ticket (e.g., `AIPCC-12842`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Jira status summary skill that generates automated status summaries for Jira tickets by analyzing child ticket activity, determining health status (green/yellow/red), and writing the summary to the ticket's status field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->