### PR TITLE
feat: add --dry-run flag to jira-status-summary skill

### DIFF
--- a/helpers/skills/jira-status-summary/SKILL.md
+++ b/helpers/skills/jira-status-summary/SKILL.md
@@ -26,6 +26,11 @@ ticket with an AI-generated health-color summary.
 This skill takes a single ticket key as input and produces a formatted status
 summary written to the Jira "Status Summary" custom field.
 
+If the user asks for a **dry run** (or uses the words "dry run", "preview",
+"don't write", "show me first"), add `--dry-run` to the write command in
+Step 4. This prints the formatted summary without writing to Jira, so the
+user can review before committing.
+
 ## Implementation
 
 ### Step 1: Determine the Ticket Key
@@ -85,6 +90,8 @@ shebang:
 
 ```bash
 ./scripts/write_status_summary.py <TICKET-KEY> --color <color> --summary "<summary text>"
+# Or for dry run:
+./scripts/write_status_summary.py <TICKET-KEY> --color <color> --summary "<summary text>" --dry-run
 ```
 
 The script will:
@@ -95,10 +102,20 @@ The script will:
 
 ### Step 5: Report Result
 
-If the write succeeds, inform the user:
+**Normal run:** If the write succeeds, inform the user:
 
 > Updated the Status Summary on <TICKET-KEY> with health color: <Color>.
 > View: https://redhat.atlassian.net/browse/<TICKET-KEY>
+
+**Dry run:** Show the formatted summary and ask:
+
+> Here is the status summary that would be written to <TICKET-KEY>:
+>
+> (show the output)
+>
+> Would you like me to write this to Jira?
+
+If the user confirms, re-run Step 4 without `--dry-run`.
 
 If the write fails, display the error message and suggest checking credentials
 and ticket permissions.

--- a/helpers/skills/jira-status-summary/scripts/write_status_summary.py
+++ b/helpers/skills/jira-status-summary/scripts/write_status_summary.py
@@ -17,11 +17,13 @@ Authentication:
 
 Usage:
   write_status_summary.py <ticket-key> --color green --summary "Summary text."
+  write_status_summary.py <ticket-key> --color green --summary "Summary text." --dry-run
 
 Examples:
   write_status_summary.py AIPCC-12345 --color green --summary "On track. Two epics completed."
   write_status_summary.py AIPCC-12345 --color yellow --summary "Some delays on Epic X."
   write_status_summary.py AIPCC-12345 --color red --summary "Blocked on dependency Y."
+  write_status_summary.py AIPCC-12345 --color green --summary "On track." --dry-run
 """
 
 import argparse
@@ -129,10 +131,22 @@ def main() -> None:
         required=True,
         help="AI-generated summary text (2-4 sentences)",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the formatted status text without writing to Jira",
+    )
     args = parser.parse_args()
 
-    auth = get_auth()
     status_text = build_status_text(args.color, args.summary)
+
+    if args.dry_run:
+        print("[DRY RUN] Would write to", args.ticket_key)
+        print()
+        print(status_text)
+        return
+
+    auth = get_auth()
     adf_value = text_to_adf(status_text)
     field_id = find_field_id(STATUS_FIELD_NAME, auth)
     write_field(args.ticket_key, field_id, adf_value, auth)


### PR DESCRIPTION
## Summary
- Add `--dry-run` flag to `write_status_summary.py` that prints the formatted status text without writing to Jira
- Update SKILL.md to instruct the agent to use `--dry-run` when the user asks for a preview
- Dry-run skips authentication, so it works without credentials set

## Test plan
- [ ] Run `./scripts/write_status_summary.py AIPCC-1 --color green --summary "test" --dry-run` and verify it prints the formatted output without making API calls
- [ ] Run without `--dry-run` to confirm normal behavior is unchanged
- [ ] Verify `--help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)