### PR TITLE
Add skip_security_audit flag to package investigator agent

### DIFF
--- a/helpers/agents/python-packaging-investigator.md
+++ b/helpers/agents/python-packaging-investigator.md
@@ -12,6 +12,10 @@ You are a specialized agent that helps developers understand how Python packages
 
 **YOU MUST ALWAYS FOLLOW THE EXACT REPORT STRUCTURE TEMPLATE defined in the "Report Structure" section below. This is MANDATORY - never provide analysis results in any other format. The template ensures comprehensive, standardized analysis that populates all required sections using the available analysis skills.**
 
+## Optional Flags
+
+- **skip_security_audit** (default: false): When `true`, skip the python-packaging-security-audit skill in Step 6 and omit the Security Assessment section from the report. Use this when the security audit has already been run separately (e.g. as a prior pipeline stage).
+
 ## Primary Responsibilities
 
 ### 1. Repository Investigation
@@ -140,7 +144,7 @@ Launch subagents in parallel using the Task tool for:
    - Task description: "Find known packaging issues for [package_name/repository]"
    - Purpose: Identify blockers, workarounds, and resolution status
 
-6. python-packaging-security-audit skill
+6. python-packaging-security-audit skill (skip if skip_security_audit is true)
    - Task description: "Run security audit for [package_name]"
    - Purpose: Static analysis and git history scan for supply-chain threats
 ```
@@ -165,7 +169,7 @@ Use all available skills in a coordinated manner to gather comprehensive data, t
 3. **license-checker** → License Compatibility section
 4. **env-finder** → Environment Investigation table
 5. **bug-finder** → Packaging Issue Analysis table
-6. **security-audit** → Security Assessment section
+6. **security-audit** → Security Assessment section (skip if skip_security_audit is true)
 
 **MANDATORY TEMPLATE STRUCTURE:**
 YOU MUST use this EXACT template structure for ALL analysis outputs. Do NOT deviate from this format under any circumstances:
@@ -257,7 +261,7 @@ YOU MUST use this EXACT template structure for ALL analysis outputs. Do NOT devi
 - **Redistribution Rights**: [wheel building and distribution permissions]
 
 ## Security Assessment
-[Use security-audit skill: Run hexora static analysis and git history scan against the cloned repository to detect supply-chain threats, malicious patterns, and suspicious commits in packaging files]
+[Omit this section if skip_security_audit is true. Otherwise, use security-audit skill: Run hexora static analysis and git history scan against the cloned repository to detect supply-chain threats, malicious patterns, and suspicious commits in packaging files]
 
 - **Risk Rating**: [no_issues/low_risk/needs_review/critical from security-audit skill]
 - **Summary**: [1-2 sentence summary from security-audit skill]
@@ -333,7 +337,7 @@ YOU MUST use this EXACT template structure for ALL analysis outputs. Do NOT devi
 - Highlight critical blockers and solutions immediately
 - Assume Claude understands Python packaging concepts
 
-Leverage all analysis skills (source-finder, complexity, license-checker, env-finder, bug-finder, security-audit) to provide comprehensive automated insights that enable successful package building from source.
+Leverage all analysis skills (source-finder, complexity, license-checker, env-finder, bug-finder, and optionally security-audit) to provide comprehensive automated insights that enable successful package building from source.
 
 ## FINAL REMINDER: MANDATORY REPORT FORMAT
 


### PR DESCRIPTION
# Pull Request Description

## Summary

Allow the security audit skill to run standalone (e.g. as a pipeline gate) by making it optional in the investigator agent. When skip_security_audit is true, Step 6 skips the security-audit subagent and the Security Assessment section is omitted from the report.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [x] 🔄 Refactoring/cleanup
- [ ] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional flag to control whether security audits run in Python packaging analysis
  * Security Assessment section is now conditionally included in generated reports based on user preference
  * Provides greater flexibility in customizing the analysis workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->