### PR TITLE
fix: code-review skill falls back to display instead of posting in CI

### DIFF
--- a/helpers/skills/code-review/SKILL.md
+++ b/helpers/skills/code-review/SKILL.md
@@ -20,26 +20,11 @@ metadata:
 Perform a structured code review of the current branch's changes and post
 results to GitLab (in CI) or display them locally.
 
-## Step 1: Detect Environment
+## Step 1: Review Code Changes
 
-Determine the execution context by checking environment variables:
-
-```bash
-echo "CI=${CI:-}" "MR_IID=${CI_MERGE_REQUEST_IID:-}"
-```
-
-- If `$CI` is set and `$CI_MERGE_REQUEST_IID` is set: **GitLab CI/MR mode** (will post review to GitLab)
-- Otherwise: **Local mode** (will display results in terminal)
-
-In CI/MR mode, the git workspace is already checked out with the branch to
-review. Use git commands to inspect the changes. Do NOT access the GitLab API
-or fetch the merge request remotely (e.g., using `glab` commands) — all the
-code you need is already in the local repository.
-
-## Step 2: Review Code Changes
-
-Review ALL commits in the branch since the base branch. Use git commands to
-understand the scope:
+Review ALL commits in the branch since the base branch. The git workspace is
+already checked out with the branch to review. Use git commands to inspect the
+changes — do NOT access remote APIs (e.g., `glab` commands).
 
 ```bash
 git log --oneline origin/main..HEAD
@@ -63,7 +48,7 @@ zero inline comments. Prioritize critical and major issues over minor stylistic
 preferences. Avoid repeating the same type of feedback across multiple
 locations — one representative comment is sufficient.
 
-## Step 3: Produce Review JSON
+## Step 2: Produce Review JSON
 
 Write your review output as a JSON file at `/tmp/ai-review-output.json`.
 
@@ -113,40 +98,32 @@ The JSON **must** be a valid object matching this schema exactly:
 
 - Omit this field entirely if there are no actionable fixes.
 
-## Step 4: Post or Display Results
+## Step 3: Post Results
 
 Run the `review.py` script from this skill's `scripts/` directory.
 Execute it directly (not via `python`) to invoke uv via the shebang:
-
-**In GitLab CI/MR mode** (both `$CI` and `$CI_MERGE_REQUEST_IID` are set):
 
 ```bash
 ./scripts/review.py post /tmp/ai-review-output.json
 ```
 
-**In local mode:**
-
-```bash
-./scripts/review.py display /tmp/ai-review-output.json
-```
-
-The script auto-detects the platform and handles:
+The script auto-detects the platform (GitLab CI, GitHub, or local) and handles:
 
 - JSON validation and chill-mode filtering (controlled by `$CHILL_MODE` env var)
 - Deduplication against previous reviews (skips comments on unchanged code)
 - Deleting previous AI review discussions on the MR (GitLab)
 - Posting inline comments and a summary note to the MR (GitLab)
-- Formatted terminal display for local mode
+- Falling back to formatted terminal display when no CI platform is detected
 
 If the script reports a JSON parse error, fix the JSON in
 `/tmp/ai-review-output.json` and re-run the command.
 
-## Step 5: Report Results
+## Step 4: Report Results
 
 After the script completes successfully:
 
-- **GitLab CI/MR mode**: Confirm the review was posted to the merge request
-- **Local mode**: The script displays results directly in the terminal
+- **CI**: Confirm the review was posted to the merge request
+- **Local**: The script displays results directly in the terminal
 - **Errors**: Report any failures from the script output
 
 ## Environment Variables

--- a/helpers/skills/code-review/scripts/review.py
+++ b/helpers/skills/code-review/scripts/review.py
@@ -716,7 +716,10 @@ def _resolve_verbose(args: argparse.Namespace) -> bool:
 
 
 def cmd_post(args: argparse.Namespace) -> None:
-    """Post review results to the detected platform."""
+    """Post review results to the detected platform.
+
+    Falls back to terminal display when no CI platform is detected.
+    """
     platform = _detect_platform()
 
     if platform == "gitlab":
@@ -724,8 +727,8 @@ def cmd_post(args: argparse.Namespace) -> None:
     elif platform == "github":
         _github_post(args)
     else:
-        _error("No CI platform detected. Use 'display' for local review output.")
-        sys.exit(1)
+        _step("No CI platform detected — displaying review locally.")
+        cmd_display(args)
 
 
 def cmd_display(args: argparse.Namespace) -> None:


### PR DESCRIPTION
# Pull Request Description

## Summary

Fix a bug where the code-review skill would display the review in the terminal instead of posting it to the GitLab MR when running in CI. The AI model was required to detect the environment in Step 1 and remember it through Steps 2-3 before choosing between `review.py post` and `review.py display` in Step 4. In practice, the model forgot the detection result and defaulted to `display`.

Observed in: https://gitlab.com/redhat/rhel-ai/agentic-ci/ai-agentic-lib/-/jobs/14050094315

## Type of Contribution

- [x] 🐛 Bug fix

## Changes Made

**`review.py`**: `cmd_post()` now falls back to `cmd_display()` when no CI platform is detected, instead of erroring out. This removes the need for the model to choose between `post` and `display`.

**`SKILL.md`**: Removed Step 1 (environment detection) entirely and renumbered remaining steps. Step 3 now always uses `review.py post` unconditionally. The script handles platform detection internally.

## Tool Details

### Skill
- **Skill name**: code-review
- **Primary use case**: AI code review on GitLab MRs or local branches
- **Dependencies required**: python3, uv, git

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- No new dependencies
- No changes to script permissions

## Additional Notes

Root cause: the skill design put a fragile decision on the model — detect the environment in Step 1, hold it in memory across Steps 2-3 (heavy git diff + file reads), then act on it in Step 4. The model's initial thinking already said "Step 4: Display results" before checking, and it never corrected course. The fix removes this decision from the model entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified code review skill documentation with consolidated review workflow and updated platform detection guidance

* **Bug Fixes**
  * Script now provides graceful fallback to local terminal output instead of error when platform detection is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->