### PR TITLE
feat: use Jira Color Status field for R/Y/G tracking

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -209,7 +209,7 @@
       },
       {
         "name": "jira-status-summary",
-        "description": "Update the Status Summary field on AIPCC Feature and Initiative tickets. Fetches child ticket activity via the jira-activity skill, generates a health-color summary (green/yellow/red), and writes it to Jira. Use when asked to update the status summary for a Jira ticket.\n",
+        "description": "Update the Status Summary and Color Status fields on AIPCC Feature and Initiative tickets. Fetches child ticket activity via the jira-activity skill, generates a brief summary and sets the red/yellow/green color status. Use when asked to update the status summary for a Jira ticket.\n",
         "category": "aipcc",
         "file_path": "helpers/skills/jira-status-summary/SKILL.md",
         "id": "jira-status-summary",

--- a/helpers/skills/jira-status-summary/SKILL.md
+++ b/helpers/skills/jira-status-summary/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: jira-status-summary
 description: >
-  Update the Status Summary field on AIPCC Feature and Initiative tickets.
-  Fetches child ticket activity via the jira-activity skill, generates a
-  health-color summary (green/yellow/red), and writes it to Jira.
+  Update the Status Summary and Color Status fields on AIPCC Feature and
+  Initiative tickets. Fetches child ticket activity via the jira-activity
+  skill, generates a brief summary and sets the red/yellow/green color status.
   Use when asked to update the status summary for a Jira ticket.
 allowed-tools: Bash
 user-invocable: true
@@ -11,8 +11,8 @@ user-invocable: true
 
 # Jira Status Summary
 
-Update the "Status Summary" custom field on an AIPCC Feature or Initiative
-ticket with an AI-generated health-color summary.
+Update the "Status Summary" and "Color Status" fields on an AIPCC Feature
+or Initiative ticket with an AI-generated summary and health color.
 
 ## Prerequisites
 
@@ -24,8 +24,9 @@ ticket with an AI-generated health-color summary.
 
 ## Usage
 
-This skill takes a single ticket key as input and produces a formatted status
-summary written to the Jira "Status Summary" custom field.
+This skill takes a single ticket key as input and writes a formatted status
+summary to the Jira "Status Summary" field and sets the "Color Status"
+dropdown.
 
 If the user asks for a **dry run** (or uses the words "dry run", "preview",
 "don't write", "show me first"), add `--dry-run` to the write command in
@@ -40,17 +41,23 @@ user can review before committing.
 2. Otherwise, search the conversation history for JIRA ticket references (e.g., "AIPCC-1234")
 3. If no ticket is found in context, ask the user: "Which ticket should I update the Status Summary for? (e.g., AIPCC-1234)"
 
-### Step 2: Fetch Previous Status Summary
+### Step 2: Fetch Previous Status Summary and Color Status
 
-Use `acli` to retrieve the current Status Summary value from the ticket:
+Fetch the previous Status Summary and Color Status from the ticket:
 
 ```bash
-acli jira workitem view <TICKET-KEY> -f 'customfield_10814' --json
+acli jira workitem view <TICKET-KEY> -f 'customfield_10814,customfield_10712' --json
 ```
 
-Parse the JSON output to extract the previous summary text. If the field is
-empty or unset, treat it as no previous summary. Save this output for use
-in Step 4.
+Parse the JSON output to extract:
+
+- `customfield_10814`: the previous summary (rich-text / ADF content)
+- `customfield_10712`: the previous color status ("Green", "Yellow", or
+  "Red")
+
+If either field is empty or unset, treat it as no previous value. Save
+both outputs for use in Step 4 -- the previous color provides trending
+context (e.g. improving from red to yellow).
 
 If the command fails (e.g., due to permissions or network issues), continue
 with Step 3 and generate the summary without prior context.
@@ -105,6 +112,10 @@ Write a brief summary (2-4 sentences) for leadership consumption covering:
   or blockers have been resolved, and flag anything that was mentioned
   previously but still has no progress
 
+For **yellow** or **red** items, the summary must also include a description
+of the issue and a "path to green" (e.g. move dates, escalation, dependency
+resolution).
+
 The summary must be self-contained and understandable without reading the
 child tickets. Do NOT include the date, color name, emoji, or disclaimer
 in the summary text -- those are added automatically by the script.
@@ -122,16 +133,18 @@ shebang:
 ```
 
 The script will:
-- Format the status string with today's date, color label, emoji, and AI disclaimer
+- Set the "Color Status" dropdown field (red/yellow/green) on the ticket
+- Format the status string with today's date and AI disclaimer (no color
+  in the text -- color is tracked in the separate "Color Status" field)
 - Convert to Atlassian Document Format (ADF)
-- Write the value to the "Status Summary" custom field on the ticket
+- Write both fields to the ticket in a single API call
 - Print a success or error message
 
 ### Step 6: Report Result
 
 **Normal run:** If the write succeeds, inform the user:
 
-> Updated the Status Summary on <TICKET-KEY> with health color: <Color>.
+> Updated the Status Summary and Color Status (<Color>) on <TICKET-KEY>.
 > View: https://redhat.atlassian.net/browse/<TICKET-KEY>
 
 **Dry run:** Show the formatted summary and ask:

--- a/helpers/skills/jira-status-summary/scripts/write_status_summary.py
+++ b/helpers/skills/jira-status-summary/scripts/write_status_summary.py
@@ -5,11 +5,11 @@
 # ]
 # ///
 """
-Write a formatted Status Summary to a Jira ticket's custom field.
+Write a Status Summary and Color Status to a Jira ticket.
 
-Builds a date-stamped status string with health color and AI disclaimer,
-converts it to Atlassian Document Format (ADF), and writes it to the
-"Status Summary" custom field via the Jira REST API v3.
+Sets the "Color Status" dropdown field (red/yellow/green) and writes a date-stamped
+summary with AI disclaimer to the "Status Summary" rich-text field, both
+via the Jira REST API v3 in a single PUT.
 
 Authentication:
   JIRA_API_TOKEN environment variable must be set with a valid API token
@@ -36,12 +36,13 @@ import requests
 JIRA_URL = "https://redhat.atlassian.net"
 API_VERSION = "3"
 API_TIMEOUT = int(os.getenv("JIRA_API_TIMEOUT", "30"))
-STATUS_FIELD_NAME = "Status Summary"
+STATUS_SUMMARY_FIELD = "customfield_10814"
+COLOR_STATUS_FIELD = "customfield_10712"
 
-COLOR_MAP = {
-    "green": ("Green", "\U0001f7e2"),
-    "yellow": ("Yellow", "\U0001f7e1"),
-    "red": ("Red", "\U0001f534"),
+COLOR_OPTION_IDS = {
+    "green": "17287",
+    "yellow": "17288",
+    "red": "17289",
 }
 
 
@@ -61,11 +62,10 @@ def get_auth() -> tuple[str, str]:
     return (email, token)
 
 
-def build_status_text(color: str, summary: str) -> str:
-    color_label, emoji = COLOR_MAP[color]
+def build_status_text(summary: str) -> str:
     date_str = datetime.now(timezone.utc).strftime("%d/%b/%Y")
     return (
-        f"{date_str} {color_label} {emoji}\n"
+        f"{date_str}\n"
         f"\u26a0\ufe0f AI-generated summary \u2014 please review before the Program Call.\n"
         f"\n"
         f"{summary}"
@@ -82,33 +82,22 @@ def text_to_adf(text: str) -> dict:
     return {"version": 1, "type": "doc", "content": paragraphs}
 
 
-def find_field_id(field_name: str, auth: tuple[str, str]) -> str:
-    resp = requests.get(
-        api_url("field"),
-        headers={"Content-Type": "application/json"},
-        auth=auth,
-        timeout=API_TIMEOUT,
-    )
-    if resp.status_code != 200:
-        print(f"ERROR: HTTP {resp.status_code} fetching fields: {resp.text}", file=sys.stderr)
-        sys.exit(1)
-    for field in resp.json():
-        if field.get("name") == field_name:
-            return field["id"]
-    print(f"ERROR: Field '{field_name}' not found in Jira metadata.", file=sys.stderr)
-    sys.exit(1)
-
-
-def write_field(ticket: str, field_id: str, adf_value: dict, auth: tuple[str, str]) -> None:
+def write_fields(ticket: str, adf_value: dict, color: str, auth: tuple[str, str]) -> None:
+    payload = {
+        "fields": {
+            STATUS_SUMMARY_FIELD: adf_value,
+            COLOR_STATUS_FIELD: {"id": COLOR_OPTION_IDS[color]},
+        }
+    }
     resp = requests.put(
         api_url(f"issue/{ticket}"),
         headers={"Content-Type": "application/json"},
-        json={"fields": {field_id: adf_value}},
+        json=payload,
         auth=auth,
         timeout=API_TIMEOUT,
     )
     if resp.status_code == 204:
-        print(f"Updated '{STATUS_FIELD_NAME}' on {ticket}")
+        print(f"Updated 'Status Summary' and 'Color Status' on {ticket}")
     else:
         print(f"ERROR: HTTP {resp.status_code} updating {ticket}: {resp.text}", file=sys.stderr)
         sys.exit(1)
@@ -138,18 +127,20 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    status_text = build_status_text(args.color, args.summary)
+    status_text = build_status_text(args.summary)
 
     if args.dry_run:
-        print("[DRY RUN] Would write to", args.ticket_key)
+        print(f"[DRY RUN] Would write to {args.ticket_key}")
         print()
+        print(f'Field "Color Status": {args.color.capitalize()}')
+        print()
+        print('Field "Status Summary":')
         print(status_text)
         return
 
     auth = get_auth()
     adf_value = text_to_adf(status_text)
-    field_id = find_field_id(STATUS_FIELD_NAME, auth)
-    write_field(args.ticket_key, field_id, adf_value, auth)
+    write_fields(args.ticket_key, adf_value, args.color, auth)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request Description

## Summary

Use the new Jira "Color Status" dropdown field for red/yellow/green health tracking instead of embedding color labels/emojis in the Status Summary text. This aligns with the standard approach across all RH AI Jira projects.

## Type of Contribution

- [x] 🔄 Refactoring/cleanup

## Changes Made

- **Script**: Sets the "Color Status" dropdown field and writes the "Status Summary" in a single PUT call. Field and option IDs are hardcoded constants matching the redhat.atlassian.net Jira instance.
- **Skill**: Updated instructions to reflect dual-field writes, added guidance for fetching previous Color Status in Step 2 for trending context, and added requirement that yellow/red summaries must include a "path to green" (issue description + resolution plan).
- **Status Summary text**: No longer includes color label or emoji — just date + AI disclaimer + summary.

### Skill
- **Skill name**: jira-status-summary
- **Primary use case**: Update Status Summary and Color Status fields on AIPCC Feature/Initiative tickets
- **Dependencies required**: Python 3 + uv, acli, JIRA_API_TOKEN/JIRA_EMAIL, jira-activity skill

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- Python scripts use proper shebang lines and PEP 723 metadata if needed
- All scripts are executable (chmod +x)
- No undocumented external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jira Status Summary now updates two fields: a rich-text "Status Summary" and a separate "Color Status" dropdown (red/yellow/green).
  * Generated summaries for yellow/red outcomes now include a brief "path to green" guidance.
  * Dry-run and success messages report both updated fields.

* **Documentation**
  * Tool descriptions and skill docs updated to reflect the expanded field handling and output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->