### PR TITLE
fix: scope code-review skill to committed diffs only

### DIFF
--- a/helpers/skills/code-review/SKILL.md
+++ b/helpers/skills/code-review/SKILL.md
@@ -34,6 +34,10 @@ git diff origin/main..HEAD
 Adjust the base branch name if different from `main` (e.g., `master`, `develop`).
 In CI, `$CI_MERGE_REQUEST_DIFF_BASE_SHA` identifies the exact base commit.
 
+**Only review the committed diff between branches.** Do NOT run `git status`,
+do NOT report on untracked files, and do NOT include uncommitted working-tree
+changes in your review.
+
 ### Review Guidelines
 
 $ARGUMENTS


### PR DESCRIPTION
# Pull Request Description

## Summary

Fix the code-review skill reporting on untracked files and uncommitted working-tree changes instead of only the committed branch diff. This caused false positives in CI (e.g. flagging `.claude-output.txt` as an issue).

## Type of Contribution

- [x] 🐛 Bug fix

## Changes Made

Added explicit instructions in Step 1 of `helpers/skills/code-review/SKILL.md` telling the model to:
- Only review the committed diff between branches
- Not run `git status`
- Not report on untracked files
- Not include uncommitted working-tree changes

## Tool Details

### Skill
- **Skill name**: code-review
- **Primary use case**: AI code review on GitLab MRs or local branches
- **Dependencies required**: python3, uv, git

## Testing and Validation

### Required Checks
- [ ] 🔄 Ran `make update` and committed any generated changes
- [ ] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

🤖 Generated with [Claude Code](https://claude.com/claude-code)