### PR TITLE
docs(google-workspace): suggest --readonly flag for gws auth login

### DIFF
--- a/helpers/skills/google-workspace/references/setup.md
+++ b/helpers/skills/google-workspace/references/setup.md
@@ -100,6 +100,12 @@ Do NOT run `gws auth setup` -- it automates via gcloud and tends to fail.
 gws auth login -s <comma-separated services they chose>
 ```
 
+If the user prefers read-only access, suggest adding the `--readonly` flag to request only read scopes:
+
+```bash
+gws auth login -s <comma-separated services they chose> --readonly
+```
+
 Example: if they chose Drive, Docs, and Sheets -> `gws auth login -s drive,docs,sheets`
 
 Keep it under ~25 scopes -- Google rejects consent for unverified apps with too many.


### PR DESCRIPTION
# Pull Request Description

## Summary
Suggest the `--readonly` flag when running `gws auth login` for users who prefer read-only access to Google Workspace services.

## Type of Contribution
- [x] 📚 Documentation update

## Changes Made
Added a note in the setup guide (`helpers/skills/google-workspace/references/setup.md`) recommending the `--readonly` flag for `gws auth login` when the user only needs read-only access to their Google Workspace data.

## Tool Details

### Skill
- **Skill name**: google-workspace
- **Primary use case**: Fetch and query data from Google Workspace
- **Dependencies required**: gws CLI

## Testing and Validation

### Required Checks
- [ ] 🔄 Ran `make update` and committed any generated changes
- [ ] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced authentication setup guidance with clarification on read-only access options, including example command reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->