### PR TITLE
docs(gws): remove nix package reference from setup

### DIFF
--- a/helpers/skills/google-workspace/references/setup.md
+++ b/helpers/skills/google-workspace/references/setup.md
@@ -9,7 +9,7 @@ One-time setup for the [Google Workspace CLI](https://github.com/googleworkspace
 
 Before walking through the steps, ask the user for the following:
 
-1. **Install method** -- Homebrew, npm, Cargo, Nix, or pre-built binary?
+1. **Install method** -- Homebrew, npm, Cargo, or pre-built binary?
 2. **GCP project name** -- What name for their Google Cloud project? (e.g. `username-gws`)
 3. **Google email** -- Their Google account email (used for OAuth consent support email and test user)
 4. **App name** -- What to call the OAuth app on the consent screen? (e.g. `gws CLI`)
@@ -20,7 +20,7 @@ Use these answers throughout the remaining steps. If the user doesn't have a pre
 ## Prerequisites
 
 - A Google account with Workspace access
-- One of: Homebrew, Node.js 18+, Rust toolchain, or Nix
+- One of: Homebrew, Node.js 18+, or Rust toolchain
 
 ## Step 1: Install
 
@@ -31,7 +31,6 @@ Use the install method the user chose:
 | Homebrew (macOS/Linux) | `brew install googleworkspace-cli` |
 | npm | `npm install -g @googleworkspace/cli` |
 | Cargo (from source) | `cargo install --git https://github.com/googleworkspace/cli --locked` |
-| Nix | `nix run github:googleworkspace/cli` |
 | Pre-built binary | Download from [GitHub Releases](https://github.com/googleworkspace/cli/releases) |
 
 Verify: `gws --help`


### PR DESCRIPTION
# Pull Request Description

## Summary

The nix install option is not relevant to the target audience of this setup guide. Closes #161.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [x] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [ ] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made

Docs update

## Testing and Validation

### Required Checks
- [ ] 🔄 Ran `make update` and committed any generated changes
- [ ] ✅ Ran `make lint` and all checks pass
- [ ] 🧪 Tested the new functionality locally

### Platform Testing
<!-- Check all that were tested -->
- [ ] Claude Code: Tested commands/skills/agents integration
- [ ] Cursor AI: Tested tool integration (if applicable)
- [ ] Gemini: Created Gem in Gemini platform and verified sharing link works (if applicable)

## Categorization
- [ ] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [ ] Updated relevant README files if needed
- [ ] Added appropriate examples and usage instructions
- [ ] Followed naming conventions for the platform


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Nix from the list of supported installation methods in the setup guide. Installation can now be performed via Homebrew, npm, Cargo (from source), or pre-built binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->