### PR TITLE
add target audience guideline for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@ Conversational AI assistants created within Google's Gemini platform. Each Gem i
 
 ### Development Workflow (All Platforms)
 
+0. **Know Your Audience**
+   - This repository is for Red Hat associates using RHEL/Fedora and macOS. When referencing upstream documentation, curate rather than copy — only include steps relevant to this audience (eg. include dnf/brew steps, omit apt/nix/etc.)
+
 1. **Plan Your Tool**
    - Identify the specific task or workflow to automate
    - Choose the appropriate platform based on requirements


### PR DESCRIPTION
- Adds a "Know Your Audience" step to the development workflow in `AGENTS.md` / `CLAUDE.md`
- Directs contributors to curate upstream docs for Red Hat associates on RHEL/Fedora and macOS, rather than copying them verbatim

Fixes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow guidelines with new introductory steps.
  * Enhanced guidance for contributors on scope and audience expectations.
  * Clarified best practices for referencing upstream documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->