### PR TITLE
test: broken skill to verify CI linter

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -363,6 +363,14 @@
         "allowed_tools": "Bash WebSearch WebFetch"
       },
       {
+        "name": "test-broken-skill",
+        "description": "",
+        "category": "general",
+        "file_path": "helpers/skills/test-broken-skill/SKILL.md",
+        "id": "test-broken-skill",
+        "allowed_tools": ""
+      },
+      {
         "name": "torchtalk-analyzer",
         "description": "Analyze PyTorch internals across Python, C++, and CUDA layers using the TorchTalk MCP server. Use when asked about how PyTorch operators work internally, where functions are implemented, what would break if code is modified, or finding tests for PyTorch operators.",
         "category": "pytorch",

--- a/helpers/skills/test-broken-skill/SKILL.md
+++ b/helpers/skills/test-broken-skill/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: test-broken-skill
+---
+
+do stuff


### PR DESCRIPTION
## Summary
- Adds a deliberately malformed skill (`test-broken-skill`) to verify the skilleval CI integration from #168 correctly catches violations
- Skill is missing the required `description` field, has no examples, and no headings

## Expected result
CI should **fail** on the lint step with:
```
Required field 'description' is missing from frontmatter
```

This PR should NOT be merged — it exists only to validate CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a test skill configuration file for verification purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->