### PR TITLE
Fix mergify config to enable auto-queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,22 +1,33 @@
 merge_protections_settings:
   auto_merge_conditions: true
 
+merge_protections:
+  - name: ci-and-review
+    if:
+      - base = main
+    success_conditions:
+      - "#approved-reviews-by >= 1"
+      - check-success = Lint
+      - check-success = Test
+      - -draft
+      - -conflict
+
 queue_rules:
   - name: maintainer
     queue_conditions:
-      - "author=@opendatahub-io/ai-helpers"
-      - "#approved-reviews-by>=1"
-      - check-success=Lint
-      - check-success=Test
+      - "author = @opendatahub-io/ai-helpers"
+      - "#approved-reviews-by >= 1"
+      - check-success = Lint
+      - check-success = Test
       - -draft
       - -conflict
     merge_method: squash
 
   - name: default
     queue_conditions:
-      - "#approved-reviews-by>=2"
-      - check-success=Lint
-      - check-success=Test
+      - "#approved-reviews-by >= 2"
+      - check-success = Lint
+      - check-success = Test
       - -draft
       - -conflict
     merge_method: squash


### PR DESCRIPTION
auto_merge_conditions only takes effect when at least one merge
protection rule with success_conditions is configured. Without it,
Mergify has no conditions to evaluate and auto-queueing never triggers.

Also restore full conditions in queue_rules (needed for manual
@mergifyio queue) and fix operator spacing per Mergify docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened merge protections for the main branch, requiring approved reviews and successful automated checks before code integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->