### PR TITLE
Tweak mergify config to fix auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,22 +1,27 @@
+merge_protections:
+  - name: maintainer
+    if:
+      - "author=@opendatahub-io/ai-helpers"
+    success_conditions:
+      - "#approved-reviews-by>=1"
+      - check-success = Lint
+      - check-success = Test
+      - -draft
+      - -conflict
+
+  - name: default
+    if:
+      - "-author=@opendatahub-io/ai-helpers"
+    success_conditions:
+      - "#approved-reviews-by>=2"
+      - check-success = Lint
+      - check-success = Test
+      - -draft
+      - -conflict
+
 merge_protections_settings:
   auto_merge_conditions: true
 
 queue_rules:
-  - name: maintainer
-    queue_conditions:
-      - "author=@opendatahub-io/ai-helpers"
-      - "#approved-reviews-by>=1"
-      - check-success=Lint
-      - check-success=Test
-      - -draft
-      - -conflict
-    merge_method: squash
-
   - name: default
-    queue_conditions:
-      - "#approved-reviews-by>=2"
-      - check-success=Lint
-      - check-success=Test
-      - -draft
-      - -conflict
     merge_method: squash


### PR DESCRIPTION
Config is based on
https://docs.mergify.com/merge-protections/auto-merge/, which states that automatic merges should be configured with
`auto_merge_conditions: true` and specific conditions that when met merge the PR (or add it to the queue). Let's hope this works 🤞

This requires:

> You'll also need to enable Merge Protections in the Mergify dashboard and mark the "Mergify Merge Protections" check as required in GitHub branch protection settings for the full flow to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD merge protection configuration to use an improved merge rules structure. Reorganized merge conditions and settings for better maintainability. These changes do not affect end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->