### PR TITLE
fix(skills): update jira-aipcc-create with complete component list

### DIFF
--- a/helpers/skills/jira-aipcc-create/SKILL.md
+++ b/helpers/skills/jira-aipcc-create/SKILL.md
@@ -30,13 +30,15 @@ Analyze the conversation to determine:
    - `Initiative`: use when capturing internal improvements
    - `Task`: unit of work to be accomplished, not end-user facing
 4. **Component**: One of the valid AIPCC components:
-   - `PyTorch`
-   - `AIPCC Productization`
    - `Accelerator Enablement`
-   - `Wheel Package Index`
+   - `AI Eng Agilist`
    - `AI Testing + Workflow Validation`
-   - `Model Validation`
+   - `AIPCC Ecosystems`
+   - `AIPCC Productization`
    - `Development Platform`
+   - `Model Validation`
+   - `PyTorch`
+   - `Wheel Package Index`
 
 5. **Parent Epic** (optional): If the user specifies an epic key (e.g. AIPCC-1234), include it as the parent
 


### PR DESCRIPTION
# Pull Request Description

## Summary

Update the jira-aipcc-create skill with the complete list of AIPCC Jira components, queried directly from the Jira API.

## Type of Contribution
- [x] 🐛 Bug fix

## Changes Made

The component list in the skill was missing two components: `AI Eng Agilist` and `AIPCC Ecosystems`. Queried the Jira API to get the full set of 9 components and sorted them alphabetically.

## Tool Details

### Skill
- **Skill name**: jira-aipcc-create
- **Primary use case**: Creating AIPCC Jira issues
- **Dependencies required**: acli

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)