### PR TITLE
feat: accept source URL in license finder and checker skills

### DIFF
--- a/helpers/skills/python-packaging-license-checker/SKILL.md
+++ b/helpers/skills/python-packaging-license-checker/SKILL.md
@@ -17,12 +17,15 @@ status.
 ## Inputs
 
 - **package_name**: Python package name
+- **repo_url**: upstream repository URL (if already known — skip the source-finder step and clone this directly)
 - **source_available**: whether buildable source exists (if already known)
 - **upstream_org**: name and primary country of the maintaining organisation (if already known)
 
 ## Step 1: Locate and clone the source repository
 
-Use the python-packaging-source-finder skill to find the upstream repo URL:
+If a `repo_url` is provided, skip the source-finder step and use the provided URL directly with the git-shallow-clone skill.
+
+Otherwise, use the python-packaging-source-finder skill to find the upstream repo URL:
 
 ```text
 Skill: python-packaging-source-finder

--- a/helpers/skills/python-packaging-license-finder/SKILL.md
+++ b/helpers/skills/python-packaging-license-finder/SKILL.md
@@ -12,6 +12,21 @@ This skill helps you deterministically find license information for Python packa
 
 When a user asks to find the license for a Python package, follow this deterministic process:
 
+### Step 0: Source URL Priority
+
+If a source repository URL is provided by the caller, skip PyPI lookup entirely:
+
+1. Pass the URL directly to the `git:shallow-clone` skill
+2. Search for LICENSE files in the cloned repository (see Step 2.3-2.4 below)
+3. Report the license found
+
+You can also use the script with a source URL to trigger this flow:
+```bash
+./scripts/find_license.py <package_name> --source-url <url>
+```
+
+If no source URL is provided, proceed with Step 1.
+
 ### Step 1: Check PyPI Metadata
 First, attempt to find the license from PyPI using the package inspection script:
 

--- a/helpers/skills/python-packaging-license-finder/scripts/find_license.py
+++ b/helpers/skills/python-packaging-license-finder/scripts/find_license.py
@@ -11,6 +11,7 @@ Usage:
 
 import argparse
 import json
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -59,8 +60,20 @@ def main():
     parser = argparse.ArgumentParser(description="Find license information for Python packages")
     parser.add_argument("package", help="Package name")
     parser.add_argument("version", nargs="?", help="Package version (optional)")
+    parser.add_argument("--source-url", help="Source repository URL (skip PyPI, clone directly)")
 
     args = parser.parse_args()
+
+    if args.source_url:
+        url = args.source_url.strip()
+        if not re.match(r"^https?://", url) or re.search(r"[\x00-\x1f]", url):
+            print(f"ERROR: Invalid source URL: {url}")
+            print("Only https:// URLs are accepted for source repositories")
+            sys.exit(1)
+        print(f"Source URL provided directly: {url}")
+        print(f"SOURCE REPOSITORY: {url}")
+        print("Use git:shallow-clone skill to search for LICENSE files in the repository")
+        sys.exit(0)
 
     # Fetch PyPI data
     print(f"Fetching PyPI data for {args.package}" + (f" {args.version}" if args.version else ""))


### PR DESCRIPTION
# Pull Request Description

## Summary

Add source URL support to the license finder and checker skills so they can skip PyPI lookup when a source repository URL is already known. This fixes license detection for packages not published on PyPI (e.g., internal packages where the JIRA ticket provides a source URL directly).

## Type of Contribution

- [x] 🐛 Bug fix
- [x] 📚 Documentation update

## Changes Made

- **`find_license.py`**: Added `--source-url` CLI argument. When provided, skips PyPI entirely and outputs `SOURCE REPOSITORY: <url>` to trigger the existing SKILL.md Step 2 clone flow.
- **License finder `SKILL.md`**: Added "Step 0: Source URL Priority" — if a source URL is provided by the caller, clone it directly and skip PyPI lookup.
- **License checker `SKILL.md`**: Added `source_url` as an optional input. Updated Step 1 to skip the source-finder step when a URL is already provided.

## Tool Details

### Skill
- **Skill name**: `python-packaging-license-finder`, `python-packaging-license-checker`
- **Primary use case**: License detection for packages where PyPI metadata is unavailable but a source repository URL is known
- **Dependencies required**: None (no new dependencies)

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- Python scripts use proper shebang lines and PEP 723 metadata if needed
- All scripts are executable (chmod +x)
- No undocumented external dependencies

## Additional Notes

Companion change in [package-onboarding](https://gitlab.com/redhat/rhel-ai/core/package-onboarding) extracts the source URL from the JIRA ticket and passes it to these skills via the license check prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional source URL input/flag to directly specify an upstream repository, allowing workflows to skip source discovery and perform a shallow clone when provided
  * Workflow now conditionally bypasses source-finder lookup when a source URL is supplied

* **Documentation**
  * Updated docs with the Source URL priority flow and usage guidance for specifying an upstream repository
<!-- end of auto-generated comment: release notes by coderabbit.ai -->