### PR TITLE
feat: integrate prodsec-skills plugin into code-review skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,14 @@
       }
     },
     {
+      "name": "prodsec-skills",
+      "description": "Red Hat Product Security skills library for secure development, security testing, and auditing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/RedHatProductSecurity/prodsec-skills.git"
+      }
+    },
+    {
       "name": "odh-ai-helpers",
       "source": "./helpers",
       "description": "AI automation tools, plugins, and assistants for enhanced productivity",

--- a/claude-external-plugin-sources.json
+++ b/claude-external-plugin-sources.json
@@ -8,6 +8,14 @@
         "source": "url",
         "url": "https://github.com/opendatahub-io/fips-compliance-checker-claude-code-plugin.git"
       }
+    },
+    {
+      "name": "prodsec-skills",
+      "description": "Red Hat Product Security skills library for secure development, security testing, and auditing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/RedHatProductSecurity/prodsec-skills.git"
+      }
     }
   ]
 }

--- a/helpers/skills/code-review/SKILL.md
+++ b/helpers/skills/code-review/SKILL.md
@@ -56,6 +56,37 @@ When referencing coding standards, security norms, best practices, or
 component-specific behavior, search for and cite the authoritative source
 (official documentation, RFCs, upstream references) to back up the claim.
 
+## Step 1.5: Optional Security Review (prodsec-skills)
+
+This step is **best-effort**. If the `prodsec-skills` plugin is not installed,
+skip this entire section and proceed to Step 2.
+
+Check whether any `prodsec-skills:*` skills are listed in your available skills.
+If none are found, skip ahead to Step 2 immediately.
+
+When the plugin is available, invoke the following skills **on the same diff**
+reviewed in Step 1. Incorporate any findings into the `inline_comments` array
+in Step 2 (use severity `critical` or `major` for security issues).
+
+1. **`prodsec-skills:differential-review`** — always invoke this.
+   It provides a structured security-focused review of the diff.
+
+2. **`prodsec-skills:input-validation-injection`** — invoke only if the diff
+   touches code that handles external input (HTTP handlers, CLI argument
+   parsing, form processing, database queries, file reads from user paths).
+
+3. **`prodsec-skills:insecure-defaults`** — invoke only if the diff touches
+   configuration, environment variable handling, authentication setup, or
+   default values for security-sensitive settings.
+
+4. **`prodsec-skills:container-hardening`** — invoke only if the diff includes
+   changes to Containerfiles, Dockerfiles, or container-related Kubernetes
+   manifests.
+
+Do not invoke skills that are not relevant to the diff. If a skill produces
+no findings, that is fine, move on. Merge any security findings from these
+skills into the review JSON produced in Step 2.
+
 ## Step 2: Produce Review JSON
 
 Write your review output as a JSON file at `/tmp/ai-review-output.json`.


### PR DESCRIPTION
# Pull Request Description

## Summary

Add the Red Hat Product Security skills plugin (`prodsec-skills`) as an external plugin source and integrate four of its skills into the code-review workflow as an optional, best-effort security review step that is skipped when the plugin is not installed.

## Type of Contribution

- [x] 🏗️ Infrastructure/tooling

## Changes Made

- **`claude-external-plugin-sources.json`**: Added `prodsec-skills` plugin entry pointing to `RedHatProductSecurity/prodsec-skills.git`
- **`helpers/skills/code-review/SKILL.md`**: Added "Step 1.5: Optional Security Review" that conditionally invokes prodsec skills when available
- **`.claude-plugin/marketplace.json`**: Auto-generated update from `make update`

### Selected prodsec skills

These four were chosen for being generic enough to apply across most codebases:

1. **`prodsec-skills:differential-review`** — structured security-focused diff review (always invoked)
2. **`prodsec-skills:input-validation-injection`** — invoked when diff touches input handling
3. **`prodsec-skills:insecure-defaults`** — invoked when diff touches config or security defaults
4. **`prodsec-skills:container-hardening`** — invoked when diff touches Containerfiles/Dockerfiles

### Design decisions

- The new section checks for `prodsec-skills:*` skill availability first and exits early if the plugin is not installed
- Skills are invoked conditionally based on what files are in the diff (not all four on every review)
- Security findings merge into the existing review JSON with `critical` or `major` severity

## Tool Details

### Skill
- **Skill name**: code-review (updated)
- **Primary use case**: Code review with optional security review layer from prodsec-skills
- **Dependencies required**: `prodsec-skills` plugin (optional, gracefully skipped if absent)

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [ ] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- The `prodsec-skills` plugin is optional. When not installed, the code-review skill works exactly as before.

## Additional Notes
- The prodsec-skills repo contains 128+ security skills, but only four were selected for code review integration. The rest (fuzzing, MCP auth, Kafka, Redis, etc.) are too specialized for general-purpose code review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional security review step in code review workflow. When available, performs differential security analysis and detects security-sensitive code patterns and configurations.

* **Documentation**
  * Updated code review skill documentation to describe the new optional security review capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->