### PR TITLE
feat: add aipcc-accel-variant-decomposer skill

### DIFF
--- a/categories.yaml
+++ b/categories.yaml
@@ -1,4 +1,5 @@
 AIPCC:
+  - aipcc-accel-variant-decomposer
   - aipcc-commit-suggest
   - commit-message-assistant
   - aipcc-adr-assistant

--- a/docs/data.json
+++ b/docs/data.json
@@ -102,6 +102,14 @@
         "allowed_tools": "Bash Read Grep Glob"
       },
       {
+        "name": "aipcc-accel-variant-decomposer",
+        "description": "Generate the EPIC decomposition for an accelerator variant release targeting\nthe AIPCC project. Handles all accelerators (CUDA, ROCm, Gaudi, Neuron, TPU,\nCPU) via a standard lifecycle and Spyre via a conditional path. Supports two\noutput modes: artifact files compatible with the epic-creator plugin, and\ndirect Jira ticket creation via acli. Use when a STRAT or feature ticket\ndescribes work for a specific accelerator variant targeting a release\nmilestone, or when asked to generate variant lifecycle EPICs. Triggers on:\n\"create variant EPICs\", \"decompose accelerator feature\", \"generate EPIC\nsequence for CUDA/ROCm/Gaudi/Neuron/TPU/CPU/Spyre\", \"variant lifecycle\",\n\"release EPICs for accelerator\".\n",
+        "category": "aipcc",
+        "file_path": "helpers/skills/aipcc-accel-variant-decomposer/SKILL.md",
+        "id": "aipcc-accel-variant-decomposer",
+        "allowed_tools": "Bash, Read, AskUserQuestion"
+      },
+      {
         "name": "code-review",
         "description": "Perform AI code review on a GitLab MR or local branch. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to GitLab (CI) or displays them locally. Use when asked to review code changes, do a code review, or run ai-review.\n",
         "category": "general",

--- a/helpers/skills/aipcc-accel-variant-decomposer/SKILL.md
+++ b/helpers/skills/aipcc-accel-variant-decomposer/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: aipcc-accel-variant-decomposer
+description: |
+  Generate the EPIC decomposition for an accelerator variant release targeting
+  the AIPCC project. Handles all accelerators (CUDA, ROCm, Gaudi, Neuron, TPU,
+  CPU) via a standard lifecycle and Spyre via a conditional path. Supports two
+  output modes: artifact files compatible with the epic-creator plugin, and
+  direct Jira ticket creation via acli. Use when a STRAT or feature ticket
+  describes work for a specific accelerator variant targeting a release
+  milestone, or when asked to generate variant lifecycle EPICs. Triggers on:
+  "create variant EPICs", "decompose accelerator feature", "generate EPIC
+  sequence for CUDA/ROCm/Gaudi/Neuron/TPU/CPU/Spyre", "variant lifecycle",
+  "release EPICs for accelerator".
+user-invocable: true
+allowed-tools: Bash, Read, AskUserQuestion
+metadata:
+  author: AIPCC
+  version: "1.0"
+  tags: aipcc, accelerator, epic, jira, decomposition
+---
+
+# Accelerator Variant Decomposer
+
+Generate the EPIC decomposition for an accelerator variant release. All
+accelerators share a common lifecycle with accelerator-specific templates.
+Spyre uses a conditional path that replaces torch/vLLM steps with wheel
+collection and index transition steps.
+
+Template definitions live in `references/epic-templates.yaml`. A Python script
+at `scripts/generate_epics.py` handles deterministic file generation for both
+artifact files and Jira JSON payloads.
+
+## Prerequisites
+
+- `acli` must be installed and authenticated (`acli jira auth`) for Jira mode
+- Python 3.10+ with `pyyaml` (`pip install pyyaml`) for the generator script
+
+## Inputs
+
+Collect these from the STRAT/feature ticket or ask the user:
+
+| Parameter | Example | Required | Notes |
+|-----------|---------|----------|-------|
+| `accelerator` | cuda, rocm, gaudi, neuron, tpu, cpu, spyre | Yes | Lowercase identifier |
+| `accel_version` | CUDA 12.9, ROCm 7.2, Gaudi 1.24 | Yes | Display name with version |
+| `variant` | cuda12.9-ubi9, spyre-ubi9 | Yes | Base image identifier |
+| `torch_version` | 2.10 | Yes (non-Spyre) | Not used for Spyre |
+| `vllm_version` | 0.19.1 | Yes (non-Spyre) | Not used for Spyre |
+| `release` | 3.5 EA1, 3.4 GA | Yes | Target release milestone |
+| `parent_feature` | AIPCC-XXXX | Yes | Parent feature ticket key |
+| `hardware_type` | NVIDIA GPU, AMD GPU, Gaudi2 | Yes | For QE/AE validation EPIC |
+| `sendnn_constraints` | torch-sendnn>=1.2.0 | No (Spyre only) | Post-release constraints |
+| `labels` | rhoai-3.5.EA2 | No | Release-specific Jira label |
+| `due_date` | 2026-06-15 | No | EPIC due date (YYYY-MM-DD) |
+
+## Execution Modes
+
+Parse `$ARGUMENTS` for mode flags:
+
+| Flag | Behavior |
+|------|----------|
+| `--artifact-only` | Generate EPIC artifact files only (epic-creator compatible) |
+| `--jira-only` | Create Jira tickets directly via acli (no artifact files) |
+| `--both` | Generate artifacts and create Jira tickets (default) |
+| `--dry-run` | Show what would be created without executing |
+
+If a Jira ticket key is found in `$ARGUMENTS`, extract parameters from it. Any
+remaining arguments are treated as overrides for the parameters above.
+
+## Template Selection
+
+The script auto-selects the template from the accelerator type. Read
+`references/epic-templates.yaml` for the full list. Summary:
+
+| Accelerator | Template | EPICs |
+|-------------|----------|-------|
+| cuda (< 13) | `standard_with_qe` | 4: base images, torch, vLLM, QE validation |
+| cuda (>= 13) | `cuda_with_modelopt` | 5: base images, torch, vLLM, Model-Opt, QE validation |
+| rocm | `rocm` | 4: stack update, torch, vLLM, AE test plan |
+| gaudi | `gaudi` | 3: stack update, torch, vLLM |
+| neuron | `standard_with_ae_testplan` | 4: stack update, torch, vLLM, AE testplan |
+| tpu | `standard_with_qe` | 4: base images, torch, vLLM, QE validation |
+| cpu | `cpu` | 4: stack update, torch, vLLM wheels, multi-arch builds |
+| spyre | `spyre` | 5-6: wheel collection, containerfile, RC images, final images (+optional constraints) |
+
+## Procedure
+
+### Step 1: Collect Parameters
+
+If a ticket key is provided (matches pattern `[A-Z]+-[0-9]+`):
+
+```bash
+acli jira workitem view <ticket-key> --output json
+```
+
+Extract accelerator type, version, release, and other parameters from the
+ticket summary and description. If any required parameter is missing, ask the
+user.
+
+### Step 2: Preview with Dry Run
+
+Run the generator script in dry-run mode to show the user what will be created:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/generate_epics.py \
+    --templates ${CLAUDE_SKILL_DIR}/references/epic-templates.yaml \
+    --accelerator <accelerator> \
+    --accel-version "<accel_version>" \
+    --variant <variant> \
+    --release "<release>" \
+    --parent-feature <parent_feature> \
+    --hardware-type "<hardware_type>" \
+    --torch-version <torch_version> \
+    --vllm-version <vllm_version> \
+    --mode <artifact|jira|both> \
+    --dry-run
+```
+
+Add `--sendnn-constraints`, `--labels`, `--due-date` if provided.
+
+Present the output to the user and wait for confirmation before proceeding.
+
+### Step 3: Generate Output
+
+Run the same command without `--dry-run`:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/generate_epics.py \
+    --templates ${CLAUDE_SKILL_DIR}/references/epic-templates.yaml \
+    --accelerator <accelerator> \
+    --accel-version "<accel_version>" \
+    --variant <variant> \
+    --release "<release>" \
+    --parent-feature <parent_feature> \
+    --hardware-type "<hardware_type>" \
+    --torch-version <torch_version> \
+    --vllm-version <vllm_version> \
+    --mode <mode> \
+    --output-dir <output_dir>
+```
+
+The script creates:
+
+- **Artifact mode**: `artifacts/epic-tasks/{parent}-decomposition.md` (summary
+  with Mermaid DAG) and `artifacts/epic-tasks/{parent}-ENNN.md` per EPIC (YAML
+  frontmatter compatible with epic-creator).
+- **Jira mode**: `artifacts/epic-tasks/jira/{parent}-ENNN-jira.json` files
+  with ADF descriptions and Red Hat Employee security level.
+
+### Step 4: Create Jira Tickets
+
+If the mode includes Jira (`--jira-only` or `--both`), create each ticket:
+
+```bash
+acli jira workitem create --from-json <jira-json-file>
+```
+
+Create EPICs in template order. On success, `acli` prints the new issue key and
+URL. Report all created EPIC keys to the user.
+
+Clean up the temporary JSON files after creation.
+
+## Error Handling
+
+- **acli not found**: Tell the user to install acli and run `acli jira auth`
+- **Authentication failure**: Tell the user to run `acli jira auth`
+- **Creation failure**: Display the error from acli and suggest checking
+  permissions or the parent feature key
+- **Missing pyyaml**: Tell the user to run `pip install pyyaml`
+- **Unknown accelerator**: The script prints valid options; relay to the user
+
+## Applicability
+
+This skill applies when the input mentions:
+
+- A specific accelerator (CUDA, ROCm, Gaudi, Neuron, TPU, CPU, Spyre)
+- A UBI9 base image variant
+- A target release milestone (EA1, EA2, GA)
+- Work to update the accelerator stack and associated components
+
+It does not apply to:
+
+- Cross-cutting release work (base image publication, delivery squad tasks)
+- Infrastructure or tooling EPICs without a fixed template
+- Day 0 platform investigations for new hardware
+- Product release lifecycle EPICs (RPMs, downstream release, etc.)
+
+$ARGUMENTS

--- a/helpers/skills/aipcc-accel-variant-decomposer/references/epic-templates.yaml
+++ b/helpers/skills/aipcc-accel-variant-decomposer/references/epic-templates.yaml
@@ -1,0 +1,226 @@
+# Accelerator Variant EPIC Templates
+#
+# Defines the EPIC decomposition templates for each accelerator type.
+# Used by generate_epics.py to produce artifact files and Jira JSON.
+#
+# Placeholders resolved at generation time:
+#   {variant}            - Full variant name (e.g., "cuda12.9-ubi9")
+#   {release}            - Release version (e.g., "3.5 EA1")
+#   {torch_version}      - PyTorch version (e.g., "2.10")
+#   {vllm_version}       - vLLM version (e.g., "0.19.1")
+#   {accel_version}      - Accelerator display name with version (e.g., "CUDA 12.9")
+#   {accelerator}        - Accelerator identifier (e.g., "cuda", "rocm")
+#   {hardware_type}      - Hardware for QE/AE validation (e.g., "NVIDIA GPU")
+#   {sendnn_constraints} - Spyre-only post-release constraints
+
+# -------------------------------------------------------------------
+# Accelerator definitions
+# -------------------------------------------------------------------
+# Each entry maps an accelerator identifier to its default template
+# and optional selection rules for version-dependent templates.
+
+accelerators:
+  cuda:
+    default_template: standard_with_qe
+    template_rules:
+      - match_version_ge: 13
+        template: cuda_with_modelopt
+    variant_suffix: "-ubi9"
+    labels:
+      - aipcc-ae-cuda
+
+  rocm:
+    default_template: rocm
+    variant_suffix: "-ubi9"
+    labels:
+      - aipcc-ae-rocm
+
+  gaudi:
+    default_template: gaudi
+    variant_suffix: "-ubi9"
+    variant_name_override: gaudi
+    labels:
+      - aipcc-ae-gaudi
+
+  neuron:
+    default_template: standard_with_ae_testplan
+    variant_suffix: "-ubi9"
+    variant_name_override: neuron
+    labels:
+      - aipcc-ae-neuron
+
+  tpu:
+    default_template: standard_with_qe
+    variant_suffix: "-ubi9"
+    variant_name_override: tpu
+    labels:
+      - aipcc-ae-tpu
+
+  cpu:
+    default_template: cpu
+    variant_suffix: "-ubi9"
+    variant_name_override: cpu
+    labels:
+      - aipcc-ae-cpu
+
+  spyre:
+    default_template: spyre
+    variant_suffix: "-ubi9"
+    variant_name_override: spyre
+    labels:
+      - aipcc-ae-spyre
+
+# -------------------------------------------------------------------
+# EPIC templates
+# -------------------------------------------------------------------
+# Each template defines a list of EPICs to create as children of the
+# parent feature ticket. Summaries and descriptions use placeholders
+# that are resolved at generation time.
+
+templates:
+  standard_with_qe:
+    epics:
+      - summary: "Update {variant} base images for {release}"
+        description: "Publish the initial development base image for {release}."
+      - summary: "Update torch to {torch_version}"
+        description: >-
+          Update PyTorch to version {torch_version} for the {variant}
+          variant targeting {release}.
+      - summary: "Update vllm to {vllm_version}"
+        description: >-
+          Update vLLM to version {vllm_version} for the {variant}
+          variant targeting {release}.
+      - summary: "QE: Validate {accelerator} packages for {release}"
+        description: >-
+          Validate that {accelerator} variant wheels from the {release}
+          package index install and function correctly on the corresponding
+          base image running on {hardware_type} hardware. Pull the {release}
+          base image, install wheels from the index, and run probe tests
+          for packages that have them; otherwise run import tests.
+
+  cuda_with_modelopt:
+    epics:
+      - summary: "Update {variant} base images for {release}"
+        description: "Publish the initial development base image for {release}."
+      - summary: "Update torch to {torch_version}"
+        description: >-
+          Update PyTorch to version {torch_version} for the {variant}
+          variant targeting {release}.
+      - summary: "Update vllm to {vllm_version}"
+        description: >-
+          Update vLLM to version {vllm_version} for the {variant}
+          variant targeting {release}.
+      - summary: "Update Model-Opt packages (speculators, llmcompressor)"
+        description: >-
+          Update Model-Opt ecosystem packages for the {variant} variant
+          targeting {release}.
+      - summary: "QE: Validate CUDA packages for {release}"
+        description: >-
+          Validate CUDA variant wheels from the {release} package index
+          install and function correctly on the corresponding base image
+          running on {hardware_type} hardware.
+
+  rocm:
+    epics:
+      - summary: "Update {variant} stack for {release}"
+        description: >-
+          Update the ROCm accelerator stack in the {variant} variant
+          for {release}.
+      - summary: "Update torch to {torch_version}"
+        description: >-
+          Update PyTorch to version {torch_version} for the {variant}
+          variant targeting {release}.
+      - summary: "Update vllm to {vllm_version}"
+        description: >-
+          Update vLLM to version {vllm_version} for the {variant}
+          variant targeting {release}.
+      - summary: "AE Test Plan for {release} for {accel_version}"
+        description: >-
+          Accelerator Engineering test plan for {accel_version}
+          targeting {release}.
+
+  gaudi:
+    epics:
+      - summary: "Update gaudi-ubi9 stack to {accel_version}"
+        description: >-
+          Update the Gaudi SDK/driver stack in base images and builder.
+      - summary: "Update torch to {torch_version}"
+        description: >-
+          Update PyTorch to version {torch_version} for the gaudi-ubi9
+          variant targeting {release}.
+      - summary: "Update vllm to {vllm_version}"
+        description: >-
+          Update vLLM to version {vllm_version} for the gaudi-ubi9
+          variant targeting {release}.
+
+  standard_with_ae_testplan:
+    epics:
+      - summary: "Update {variant} stack for {release}"
+        description: >-
+          Update the {accelerator} accelerator stack for {release}.
+      - summary: "Update torch to {torch_version}"
+        description: >-
+          Update PyTorch to version {torch_version} for the {variant}
+          variant targeting {release}.
+      - summary: "Update vllm to {vllm_version}"
+        description: >-
+          Update vLLM to version {vllm_version} for the {variant}
+          variant targeting {release}.
+      - summary: "AE TestPlan: Validate {accelerator} for {release}"
+        description: >-
+          Accelerator Engineering test plan for {accelerator}
+          targeting {release}.
+
+  cpu:
+    epics:
+      - summary: "Update cpu-ubi9 stack for {release}"
+        description: "Update the CPU accelerator stack for {release}."
+      - summary: "Update torch to {torch_version}"
+        description: >-
+          Update PyTorch to version {torch_version} for the cpu-ubi9
+          variant targeting {release}.
+      - summary: "Deliver cpu-ubi9 wheels for vLLM {vllm_version}"
+        description: >-
+          Deliver CPU wheels for vLLM {vllm_version} targeting {release}.
+      - summary: "Build and publish CPU-only wheel packages on ppc64le and s390x"
+        description: >-
+          Multi-architecture CPU wheel builds for IBM Power and IBM Z.
+
+  spyre:
+    epics:
+      - summary: "Update wheels in the builder collection"
+        description: >-
+          Update the Spyre wheel collection in the builder for {release}.
+      - summary: "Update wheel collections"
+        description: >-
+          Update wheel collections to support new package builds.
+          Child stories: Update wheel collection in rhaiis/pipeline,
+          Update wheel collections in rhai/pipeline.
+      - summary: "RHAII Containerfile/environment variable updates"
+        description: >-
+          Update RHAII containerfile/env variable/entrypoint to support
+          new Spyre stack.
+      - summary: "Create and share RC images for test with IBM"
+        description: >-
+          Create and share RC images for test with IBM. Depends on
+          base image and wheel collections.
+      - summary: "Create customer-facing base images for IBM Spyre"
+        description: >-
+          Create final customer-facing base images for IBM Spyre.
+          Depends on RC images and testing.
+    optional_epics:
+      - condition: sendnn_constraints
+        summary: "Post-{release}: add Spyre constraints to global constraints in builder"
+        description: >-
+          After {release}, add the following constraints to builder:
+          {sendnn_constraints}.
+
+# -------------------------------------------------------------------
+# Jira defaults
+# -------------------------------------------------------------------
+
+jira:
+  project: AIPCC
+  type: Epic
+  component: "AIPCC Ecosystems"
+  security: "Red Hat Employee"

--- a/helpers/skills/aipcc-accel-variant-decomposer/scripts/generate_epics.py
+++ b/helpers/skills/aipcc-accel-variant-decomposer/scripts/generate_epics.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Generate EPIC artifact files and/or Jira JSON for accelerator variant releases.
+
+Reads template definitions from epic-templates.yaml, resolves placeholders,
+and writes output files in one of two formats:
+
+- artifact: per-EPIC markdown files with YAML frontmatter (epic-creator compatible)
+- jira: JSON files for ``acli jira workitem create --from-json``
+
+Usage:
+    python3 generate_epics.py \\
+        --templates references/epic-templates.yaml \\
+        --accelerator cuda --accel-version "CUDA 12.9" \\
+        --variant cuda12.9-ubi9 --release "3.5 EA1" \\
+        --torch-version 2.10 --vllm-version 0.19.1 \\
+        --parent-feature AIPCC-XXXX --hardware-type "NVIDIA GPU" \\
+        --mode both --output-dir artifacts/epic-tasks
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import sys
+import textwrap
+from pathlib import Path
+
+import yaml
+
+
+def load_templates(path: Path) -> dict:
+    """Load and validate the epic-templates.yaml file."""
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    for key in ("accelerators", "templates", "jira"):
+        if key not in data:
+            print(f"Error: missing required key '{key}' in {path}", file=sys.stderr)
+            sys.exit(1)
+    return data
+
+
+def select_template(
+    config: dict, accelerator: str, accel_version: str
+) -> tuple[str, list[dict], list[dict]]:
+    """Return (template_name, epics, optional_epics) for the accelerator."""
+    accel_def = config["accelerators"].get(accelerator)
+    if not accel_def:
+        valid = ", ".join(sorted(config["accelerators"]))
+        print(
+            f"Error: unknown accelerator '{accelerator}'. Valid: {valid}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    template_name = accel_def["default_template"]
+
+    for rule in accel_def.get("template_rules", []):
+        if "match_version_ge" in rule:
+            version_num = extract_version_number(accel_version)
+            if version_num is not None and version_num >= rule["match_version_ge"]:
+                template_name = rule["template"]
+                break
+
+    template = config["templates"].get(template_name)
+    if not template:
+        print(
+            f"Error: template '{template_name}' not found in templates",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return template_name, template["epics"], template.get("optional_epics", [])
+
+
+def extract_version_number(accel_version: str) -> float | None:
+    """Extract the leading numeric version from a string like 'CUDA 12.9'."""
+    match = re.search(r"(\d+(?:\.\d+)?)", accel_version)
+    if match:
+        return float(match.group(1))
+    return None
+
+
+def resolve_placeholders(text: str, params: dict[str, str]) -> str:
+    """Replace {placeholder} tokens with parameter values."""
+    result = text
+    for key, value in params.items():
+        result = result.replace(f"{{{key}}}", value)
+    remaining = re.findall(r"\{(\w+)\}", result)
+    if remaining:
+        print(f"Warning: unresolved placeholders: {remaining}", file=sys.stderr)
+    return result
+
+
+def build_params(args: argparse.Namespace) -> dict[str, str]:
+    """Build the placeholder parameters dict from CLI arguments."""
+    params: dict[str, str] = {
+        "accelerator": args.accelerator,
+        "accel_version": args.accel_version,
+        "variant": args.variant,
+        "release": args.release,
+        "hardware_type": args.hardware_type,
+        "parent_feature": args.parent_feature,
+    }
+    if args.torch_version:
+        params["torch_version"] = args.torch_version
+    if args.vllm_version:
+        params["vllm_version"] = args.vllm_version
+    if args.sendnn_constraints:
+        params["sendnn_constraints"] = args.sendnn_constraints
+    return params
+
+
+def build_epic_list(
+    epics: list[dict],
+    optional_epics: list[dict],
+    params: dict[str, str],
+) -> list[dict[str, str]]:
+    """Resolve placeholders and filter optional EPICs by condition."""
+    result = []
+    for epic in epics:
+        result.append(
+            {
+                "summary": resolve_placeholders(epic["summary"], params),
+                "description": resolve_placeholders(epic["description"], params),
+            }
+        )
+    for opt in optional_epics:
+        condition_key = opt.get("condition", "")
+        if condition_key and params.get(condition_key):
+            result.append(
+                {
+                    "summary": resolve_placeholders(opt["summary"], params),
+                    "description": resolve_placeholders(opt["description"], params),
+                }
+            )
+    return result
+
+
+def write_artifact_files(
+    epic_list: list[dict[str, str]],
+    parent_feature: str,
+    output_dir: Path,
+    dry_run: bool,
+) -> list[str]:
+    """Write epic-creator compatible artifact files."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    created: list[str] = []
+
+    decomp_path = output_dir / f"{parent_feature}-decomposition.md"
+    epic_count = len(epic_list)
+    decomp_content = textwrap.dedent(f"""\
+        ---
+        parent_strat: "{parent_feature}"
+        epic_count: {epic_count}
+        critical_path_length: {epic_count}
+        triage: "templated-variant"
+        triage_rationale: "Accelerator variant lifecycle"
+        ---
+
+        ## Epic List
+
+        | # | ID | Title | Type | Priority |
+        |---|-----|-------|------|----------|
+    """)
+    for i, epic in enumerate(epic_list, 1):
+        epic_id = f"{parent_feature}-E{i:03d}"
+        decomp_content += f"| {i} | {epic_id} | {epic['summary']} | Implementation | P0 |\n"
+
+    decomp_content += "\n## Dependency DAG\n\n```mermaid\ngraph LR\n"
+    for i in range(1, epic_count + 1):
+        epic_id = f"{parent_feature}-E{i:03d}"
+        if i < epic_count:
+            next_id = f"{parent_feature}-E{i + 1:03d}"
+            decomp_content += f"    {epic_id} --> {next_id}\n"
+        else:
+            decomp_content += f"    {epic_id}\n"
+    decomp_content += "```\n"
+
+    if dry_run:
+        print(f"[dry-run] Would write: {decomp_path}")
+        print(decomp_content)
+    else:
+        decomp_path.write_text(decomp_content, encoding="utf-8")
+        created.append(str(decomp_path))
+
+    for i, epic in enumerate(epic_list, 1):
+        epic_id = f"{parent_feature}-E{i:03d}"
+        deps = [f"{parent_feature}-E{i - 1:03d}"] if i > 1 else []
+        deps_yaml = "\n".join(f'  - "{d}"' for d in deps) if deps else "[]"
+
+        content = textwrap.dedent(f"""\
+            ---
+            epic_id: "{epic_id}"
+            parent_strat: "{parent_feature}"
+            component: "AIPCC Ecosystems"
+            team: ""
+            type: "Implementation"
+            implementation_type: null
+            priority: "P0"
+            dependencies: {deps_yaml}
+            ai_signals:
+              change_specificity: 1
+              pattern_precedent: 1
+              adapter_pattern: 0
+              existing_foundation: 1
+              open_questions: 0
+              external_dependency: 0
+              human_process_gates: 0
+              repo_access: 1
+              architecture_claims: 0
+            ---
+
+            # {epic["summary"]}
+
+            ## Description
+
+            {epic["description"]}
+
+            ## Acceptance Criteria
+
+            - [ ] Implementation complete and tested
+            - [ ] Changes merged to target branch
+        """)
+
+        epic_path = output_dir / f"{epic_id}.md"
+        if dry_run:
+            print(f"[dry-run] Would write: {epic_path}")
+        else:
+            epic_path.write_text(content, encoding="utf-8")
+            created.append(str(epic_path))
+
+    return created
+
+
+def write_jira_files(
+    epic_list: list[dict[str, str]],
+    parent_feature: str,
+    jira_config: dict,
+    output_dir: Path,
+    dry_run: bool,
+    labels: str | None = None,
+    due_date: str | None = None,
+) -> list[str]:
+    """Write Jira JSON files for acli workitem create."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    created: list[str] = []
+
+    for i, epic in enumerate(epic_list, 1):
+        additional: dict = {
+            "components": [{"name": jira_config["component"]}],
+            "parent": {"key": parent_feature},
+            "security": {"name": jira_config["security"]},
+        }
+        if labels:
+            additional["labels"] = [labels]
+        if due_date:
+            additional["duedate"] = due_date
+
+        payload = {
+            "projectKey": jira_config["project"],
+            "type": jira_config["type"],
+            "summary": epic["summary"],
+            "description": {
+                "version": 1,
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {"type": "text", "text": epic["description"]},
+                        ],
+                    }
+                ],
+            },
+            "additionalAttributes": additional,
+        }
+
+        filename = f"{parent_feature}-E{i:03d}-jira.json"
+        jira_path = output_dir / filename
+        if dry_run:
+            print(f"[dry-run] Would write: {jira_path}")
+            print(json.dumps(payload, indent=2))
+        else:
+            jira_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+            created.append(str(jira_path))
+
+    return created
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate EPIC decomposition for accelerator variant releases.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--templates",
+        type=Path,
+        required=True,
+        help="Path to epic-templates.yaml",
+    )
+    parser.add_argument("--accelerator", required=True, help="Accelerator identifier")
+    parser.add_argument("--accel-version", required=True, help="Display name with version")
+    parser.add_argument("--variant", required=True, help="Base image identifier")
+    parser.add_argument("--release", required=True, help="Target release milestone")
+    parser.add_argument("--parent-feature", required=True, help="Parent feature key")
+    parser.add_argument("--hardware-type", required=True, help="Hardware type for QE")
+    parser.add_argument("--torch-version", default=None, help="PyTorch version")
+    parser.add_argument("--vllm-version", default=None, help="vLLM version")
+    parser.add_argument("--sendnn-constraints", default=None, help="Spyre post-release constraints")
+    parser.add_argument("--labels", default=None, help="Jira label to apply")
+    parser.add_argument("--due-date", default=None, help="EPIC due date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--mode",
+        choices=["artifact", "jira", "both"],
+        default="both",
+        help="Output mode (default: both)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/epic-tasks"),
+        help="Output directory (default: artifacts/epic-tasks)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be created without writing files",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point."""
+    args = parse_args(argv)
+
+    if not args.templates.exists():
+        print(f"Error: templates file not found: {args.templates}", file=sys.stderr)
+        sys.exit(1)
+
+    if not re.match(r"^[A-Z]+-\d+$", args.parent_feature):
+        print(
+            f"Error: invalid parent-feature key '{args.parent_feature}' "
+            f"(expected format: PROJ-12345)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if args.due_date:
+        try:
+            datetime.date.fromisoformat(args.due_date)
+        except ValueError:
+            print(
+                f"Error: --due-date must be YYYY-MM-DD, got '{args.due_date}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    args.accelerator = args.accelerator.lower()
+
+    config = load_templates(args.templates)
+
+    if args.accelerator != "spyre":
+        if not args.torch_version or not args.vllm_version:
+            print(
+                f"Error: --torch-version and --vllm-version are required "
+                f"for accelerator '{args.accelerator}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    template_name, epics, optional_epics = select_template(
+        config, args.accelerator, args.accel_version
+    )
+
+    params = build_params(args)
+    epic_list = build_epic_list(epics, optional_epics, params)
+
+    print(f"Template: {template_name}")
+    print(f"EPICs to generate: {len(epic_list)}")
+    for i, epic in enumerate(epic_list, 1):
+        print(f"  {i}. {epic['summary']}")
+    print()
+
+    created_files: list[str] = []
+
+    if args.mode in ("artifact", "both"):
+        files = write_artifact_files(epic_list, args.parent_feature, args.output_dir, args.dry_run)
+        created_files.extend(files)
+
+    jira_dir = args.output_dir / "jira"
+    if args.mode in ("jira", "both"):
+        files = write_jira_files(
+            epic_list,
+            args.parent_feature,
+            config["jira"],
+            jira_dir,
+            args.dry_run,
+            labels=args.labels,
+            due_date=args.due_date,
+        )
+        created_files.extend(files)
+
+    if not args.dry_run and created_files:
+        print(f"\nCreated {len(created_files)} files:")
+        for f in created_files:
+            print(f"  {f}")
+
+    if args.mode in ("jira", "both") and not args.dry_run:
+        print("\nTo create Jira tickets, run:")
+        for f in created_files:
+            if f.endswith("-jira.json"):
+                print(f"  acli jira workitem create --from-json {f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request Description

## Summary

Add a new first-class skill for generating EPIC decompositions for accelerator variant releases targeting the AIPCC project. Combines the best ideas from three existing implementations into a single reusable skill with bundled templates and a deterministic generator script.

## Type of Contribution

- [x] 🎯 New skill
- [x] 📋 New category addition

## Changes Made

- **SKILL.md**: Procedure for collecting parameters (from ticket or user), previewing with dry-run, generating output, and creating Jira tickets via acli
- **references/epic-templates.yaml**: Template definitions for 7 accelerator types (CUDA, ROCm, Gaudi, Neuron, TPU, CPU, Spyre) with version-dependent template selection rules
- **scripts/generate_epics.py**: Python CLI tool that reads templates, resolves placeholders, and writes epic-creator compatible artifact files and/or Jira JSON with ADF descriptions
- **categories.yaml**: Added `aipcc-accel-variant-decomposer` to the AIPCC category
- **docs/data.json**: Auto-generated by `make update`

## Tool Details

### Skill
- **Skill name**: aipcc-accel-variant-decomposer
- **Primary use case**: Generate EPIC decomposition (artifact files + Jira tickets) for accelerator variant releases in the AIPCC project
- **Dependencies required**: Python 3.10+ with `pyyaml`, `acli` (for Jira mode only)

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested commands/skills/agents integration

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- Python scripts use proper shebang lines
- `generate_epics.py` passes `ruff check` and `ruff format --check`
- No undocumented external dependencies (only `pyyaml`)

## Additional Notes

This skill consolidates three prior implementations:
1. A standalone gist with clean EPIC templates and Spyre conditional path
2. A spreadsheet-driven skill with 7 template types and JIRA creation via acli
3. The epic-creator plugin's artifact format (YAML frontmatter, dependency DAGs, AI implementability signals)

The model handles judgment work (parameter collection, template selection, user confirmation) while the Python script handles deterministic work (file generation, ADF formatting, Mermaid DAGs).