### PR TITLE
feat: add autofix-skills external plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,14 @@
       }
     },
     {
+      "name": "autofix-skills",
+      "description": "Automated Jira bug fixing, CVE remediation, and ticket triage",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/opendatahub-io/autofix-skills.git"
+      }
+    },
+    {
       "name": "odh-ai-helpers",
       "source": "./helpers",
       "description": "AI automation tools, plugins, and assistants for enhanced productivity",

--- a/claude-external-plugin-sources.json
+++ b/claude-external-plugin-sources.json
@@ -8,6 +8,14 @@
         "source": "url",
         "url": "https://github.com/opendatahub-io/fips-compliance-checker-claude-code-plugin.git"
       }
+    },
+    {
+      "name": "autofix-skills",
+      "description": "Automated Jira bug fixing, CVE remediation, and ticket triage",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/opendatahub-io/autofix-skills.git"
+      }
     }
   ]
 }


### PR DESCRIPTION
Register the opendatahub-io/autofix-skills repository as an external plugin so its skills are exposed when the marketplace is enabled.

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

