### PR TITLE
Enable autofix-skills plugin by default

### DIFF
--- a/images/claude/claude-settings.json
+++ b/images/claude/claude-settings.json
@@ -8,6 +8,7 @@
     }
   },
   "enabledPlugins": {
-    "odh-ai-helpers@odh-ai-helpers": true
+    "odh-ai-helpers@odh-ai-helpers": true,
+    "odh-ai-helpers@autofix-skills": true
   }
 }

--- a/images/claude/claude-settings.json
+++ b/images/claude/claude-settings.json
@@ -9,6 +9,7 @@
   },
   "enabledPlugins": {
     "odh-ai-helpers@odh-ai-helpers": true,
+    "odh-ai-helpers@fips-compliance-checker": true,
     "odh-ai-helpers@autofix-skills": true
   }
 }

--- a/scripts/update_claude_settings.py
+++ b/scripts/update_claude_settings.py
@@ -229,7 +229,7 @@ def load_external_plugins(config_path: Path) -> List[Dict]:
     return external_plugins
 
 
-def generate_claude_settings(categories_config: Dict) -> Dict:
+def generate_claude_settings(categories_config: Dict, external_plugins: List[Dict]) -> Dict:
     """Generate Claude Code settings configuration."""
 
     # Base configuration
@@ -242,6 +242,12 @@ def generate_claude_settings(categories_config: Dict) -> Dict:
 
     # Enable the single plugin containing all helpers
     settings["enabledPlugins"]["odh-ai-helpers@odh-ai-helpers"] = True
+
+    # Enable external plugins
+    for plugin in external_plugins:
+        name = plugin.get("name")
+        if isinstance(name, str):
+            settings["enabledPlugins"][f"odh-ai-helpers@{name}"] = True
 
     return settings
 
@@ -382,7 +388,7 @@ def main():
         print(f"Found external plugins: {', '.join(ext_names)}")
 
     print("Generating Claude settings...")
-    settings = generate_claude_settings(categories_config)
+    settings = generate_claude_settings(categories_config, external_plugins)
 
     print(f"Writing {settings_path}...")
     write_settings_file(settings_path, settings)


### PR DESCRIPTION
This way it can be consumed in downstream CI jobs that make use of the ai-helpers image and don't want to have an extra step to enable specific plugins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two additional assistant helper plugins added to expand available assistance (compliance checking and automatic fix suggestions).
  * Configuration generation updated to include external helper plugins so settings now reflect those enabled plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->