### PR TITLE
ci: add unicode safety check to protect against skills/context poisoning

### DIFF
--- a/.github/workflows/unicode-safety.yml
+++ b/.github/workflows/unicode-safety.yml
@@ -1,0 +1,18 @@
+name: Unicode Safety Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unicode-safety:
+    name: Detect hidden unicode characters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - uses: dcondrey/unicode-safety-check@0ee6d0bec92c640765f97a0514a9cf1613a34162 # v3.0.0


### PR DESCRIPTION
## Summary

Adds a GitHub Action that scans pull requests for hidden Unicode characters used in [ASCII smuggling](https://marcogerber.ch/ascii-smuggling-a-threat-hidden-in-plain-sight/) attacks.

All markdown-based AI agent skill files (CLAUDE.md, AGENTS.md, skills, commands, context docs) are vulnerable to skills/context poisoning - a technique where invisible Unicode characters encode hidden instructions that are invisible to humans but processed by LLMs. Several models (e.g. available through Cursor) do not guardrail against this, as confirmed by a PoC demonstrating exfiltration of system information via tag characters hidden in a cursor command file.

## What this checks

The action ([dcondrey/unicode-safety-check](https://github.com/dcondrey/unicode-safety-check)) runs 19 detection rules covering:

- **Tag characters** (U+E0001-E007F) - the primary ASCII smuggling vector
- **Zero-width characters** (U+200B-200D) - invisible joiners/spaces
- **Bidi overrides** (U+202A-202E, U+2066-2069) - Trojan Source attacks
- **Variation selectors** (Glassworm-style encoding)
- **Homoglyphs and confusable identifiers**
- **Private Use Area characters**

Both actions are pinned to commit SHAs for supply chain integrity.

## Alternative considered

[pierDipi/unicode-control-characters-action](https://github.com/pierDipi/unicode-control-characters-action) by @pierDipi detects all Unicode `Cf` category characters, which covers tag characters and zero-width chars (the primary smuggling vectors). However, it does not cover more recent attack techniques such as variation selectors (Glassworm encoding, Unicode category `Mn`) and Private Use Area characters (`Co`). We could consider contributing these checks upstream since @pierDipi is no stranger :)