### PR TITLE
Prefetch external plugins at container image build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ venv/
 
 # Ignore agentready reports
 .agentready/
+
+# External plugin repos fetched by scripts/fetch_external_plugins.py
+external-plugins/

--- a/images/claude/Containerfile
+++ b/images/claude/Containerfile
@@ -92,6 +92,10 @@ RUN useradd -m -u 1000 -s /bin/bash claude
 
 # Copy ai-helpers repository to /opt/ai-helpers
 COPY . /opt/ai-helpers
+
+# Fetch external plugin repos so their skills are available in non-interactive mode
+RUN python3 /opt/ai-helpers/scripts/fetch_external_plugins.py /opt/ai-helpers
+
 RUN chown -R claude:claude /opt/ai-helpers
 
 # Create Claude configuration directory and copy settings

--- a/scripts/fetch_external_plugins.py
+++ b/scripts/fetch_external_plugins.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Fetch external plugin repositories and rewrite marketplace.json to use local paths.
+
+Used during container builds so that external plugin skills are available
+in non-interactive mode (claude -p), where Claude Code does not fetch URL sources.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    repo_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).parent.parent
+
+    sources_path = repo_root / "claude-external-plugin-sources.json"
+    marketplace_path = repo_root / ".claude-plugin" / "marketplace.json"
+
+    with open(sources_path, encoding="utf-8") as f:
+        external_config = json.load(f)
+
+    plugins = external_config.get("plugins", [])
+    if not plugins:
+        print("No external plugins to fetch.")
+        return
+
+    plugins_dir = repo_root / "external-plugins"
+    plugins_dir.mkdir(exist_ok=True)
+
+    fetched = {}
+    for plugin in plugins:
+        name = plugin["name"]
+        url = plugin["source"]["url"]
+        dest = plugins_dir / name
+
+        if dest.exists():
+            print(f"Skipping {name}: {dest} already exists")
+        else:
+            print(f"Cloning {name} from {url}...")
+            subprocess.run(
+                ["git", "clone", "--depth", "1", url, str(dest)],
+                check=True,
+            )
+
+        fetched[name] = f"./external-plugins/{name}"
+
+    with open(marketplace_path, encoding="utf-8") as f:
+        marketplace = json.load(f)
+
+    for entry in marketplace.get("plugins", []):
+        if entry.get("name") in fetched:
+            entry["source"] = fetched[entry["name"]]
+
+    with open(marketplace_path, "w", encoding="utf-8") as f:
+        json.dump(marketplace, f, indent=2)
+        f.write("\n")
+
+    print(f"Patched {marketplace_path} — replaced {len(fetched)} URL source(s) with local paths.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request Description

## Summary
When running claude non-interactively, it does not resolve external plugins specified in the marketplace via URLs. This change resolves those plugins when the container image is built, clones shallow copies of the repos and adds them to the ai-helpers marketplace. It also overwrites the marketplace JSON file to point to the local clone of the skills.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [ ] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [x] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made

Changes in how external plugins are loaded into the ai-helpers image.

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

Tested with:

```
podman run --rm \
        --userns=keep-id \
        -e CLAUDE_CODE_USE_VERTEX=1 \
        -e CLOUD_ML_REGION="${CLOUD_ML_REGION}" \
        -e ANTHROPIC_VERTEX_PROJECT_ID="${ANTHROPIC_VERTEX_PROJECT_ID}" \
        -e DISABLE_AUTOUPDATER=1 \
        -v ~/.config/gcloud:/home/claude/.config/gcloud:ro,z \
        -v ~/.claude.json:/home/claude/.claude.json:z \
        -w /opt/ai-helpers \
        localhost/ai-helpers:latest -p "Do you have any skills with 'autofix' in their name? List them
      specifically. Also list any skills from the autofix-skills or fips-compliance-checker plugins."
```

All four autofix plugins were shown.

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform
