### PR TITLE
Include scripts directory when merging external plugins

### DIFF
--- a/scripts/fetch_external_plugins.py
+++ b/scripts/fetch_external_plugins.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-CONTENT_DIRS = ("skills", "agents", "commands", "gems")
+CONTENT_DIRS = ("skills", "agents", "commands", "gems", "scripts")
 
 
 def main():


### PR DESCRIPTION
The fetch_external_plugins.py script only copied skills, agents, commands, and gems from external plugin repos. The autofix-skills plugin also ships a scripts/ directory (state.py, merge_findings.py, cve_pipeline.py) that skills reference via CLAUDE_SKILL_DIR. Without copying scripts/, the agent wastes tokens reimplementing the logic these scripts provide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced external plugin integration to properly include script files from plugin repositories during the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->