### PR TITLE
Clean up CI lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
-        python-version: '3.x'
+        python-version: '3.13'
 
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -27,19 +27,10 @@ jobs:
         enable-cache: true
 
     - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y make shellcheck
+      run: sudo apt-get update && sudo apt-get install -y shellcheck
 
     - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install ruff PyYAML skillsaw
-
-    - name: Run skillsaw
-      uses: stbenjam/skillsaw@d252498eb6260e197c9c395a650643d9c49ae37b # v0
-      with:
-        strict: true
+      run: uv pip install --system ruff PyYAML skillsaw
 
     - name: Run lint
       env:


### PR DESCRIPTION
## Summary

- Remove duplicate skillsaw run (the standalone action step + `make lint` both ran it)
- Drop `make` from apt-get install (pre-installed on ubuntu-latest)
- Pin Python to 3.13 instead of floating `3.x`
- Use `uv pip install` instead of plain `pip` (uv is already installed for `make update`)

## Test plan

- [ ] CI lint workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)