### PR TITLE
[Feature] Add torch-request-skills external plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,14 @@
       }
     },
     {
+      "name": "torch-request-skills",
+      "description": "File PyTorch team build/external/internal/team requests to Jira.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/TorchedHat/torch-request-skills.git"
+      }
+    },
+    {
       "name": "odh-ai-helpers",
       "source": "./helpers",
       "description": "AI automation tools, plugins, and assistants for enhanced productivity",

--- a/claude-external-plugin-sources.json
+++ b/claude-external-plugin-sources.json
@@ -16,6 +16,14 @@
         "source": "url",
         "url": "https://github.com/opendatahub-io/autofix-skills.git"
       }
+    },
+    {
+      "name": "torch-request-skills",
+      "description": "File PyTorch team build/external/internal/team requests to Jira.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/TorchedHat/torch-request-skills.git"
+      }
     }
   ]
 }

--- a/images/claude/claude-settings.json
+++ b/images/claude/claude-settings.json
@@ -10,6 +10,7 @@
   "enabledPlugins": {
     "odh-ai-helpers@odh-ai-helpers": true,
     "odh-ai-helpers@fips-compliance-checker": true,
-    "odh-ai-helpers@autofix-skills": true
+    "odh-ai-helpers@autofix-skills": true,
+    "odh-ai-helpers@torch-request-skills": true
   }
 }


### PR DESCRIPTION
Summary
Part of the AIPCC AI First Initiative.  Registers thetorch-request-skills (https://github.com/TorchedHat/torch-request-skills) repository as an external plugin in the marketplace. The plugin exposes four pipelines for filing PyTorch team inbound requests (build deliverables, external asks, internal asks, team escalations) to Jira via 12 /torch.* skills.

Type of Contribution
- [x] 🏗️ Infrastructure/tooling

Changes Made

- Appended a torch-request-skills entry to claude-external-plugin-sources.json and .claude-plugin/marketplace.json (the latter ordered before the internal odh-ai-helpers entry per existing convention).
- Regenerated images/claude/claude-settings.json via make update.

Testing and Validation / Required Checks
- [x] 🔄 Ran make update and committed any generated changes 
- [x] ✅ Ran make lint and all checks pass
- [x] 🧪 Tested locally: make update detects the entry (Found external plugins: ..., torch-request-skills) and the plugin repo is publicly cloneable

Categorization
- [x] External plugin : uses the default "General" category.

Documentation
- [x] Plugin follows the torch.<pipeline>.<stage> naming convention; userfacing README in the plugin repo documents install, the 4-pipeline command table, and the Jira env-var setup.
