### PR TITLE
Skill/compliance non redhat rpms

### DIFF
--- a/categories.yaml
+++ b/categories.yaml
@@ -53,3 +53,6 @@ Team Management:
 
 Git Workflows:
   - github-sync-upstream
+
+Compliance:
+  - non-redhat-rpms

--- a/docs/data.json
+++ b/docs/data.json
@@ -28,6 +28,9 @@
     },
     "git workflows": {
       "name": "Git Workflows"
+    },
+    "compliance": {
+      "name": "Compliance"
     }
   },
   "tools": {
@@ -362,6 +365,14 @@
         "file_path": "helpers/skills/learning-mode/SKILL.md",
         "id": "learning-mode",
         "allowed_tools": ""
+      },
+      {
+        "name": "non-redhat-rpms",
+        "description": "Use this skill to identify non-Red Hat RPM packages installed in container images or on the local machine. For containers, pulls images across multiple architectures and release tags; for local scans, inspects the host directly. Extracts RPM signing metadata and reports packages not signed with the Red Hat GPG key as CSV output. Use when auditing compliance, checking supply-chain provenance, or scanning for third-party RPMs in RHOAI component images.\n",
+        "category": "compliance",
+        "file_path": "helpers/skills/non-redhat-rpms/SKILL.md",
+        "id": "non-redhat-rpms",
+        "allowed_tools": "Bash"
       },
       {
         "name": "oci-cve-checker",

--- a/helpers/skills/non-redhat-rpms/SKILL.md
+++ b/helpers/skills/non-redhat-rpms/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: non-redhat-rpms
+description: >
+  Use this skill to identify non-Red Hat RPM packages installed in container
+  images or on the local machine. For containers, pulls images across multiple
+  architectures and release tags; for local scans, inspects the host directly.
+  Extracts RPM signing metadata and reports packages not signed with the Red Hat
+  GPG key as CSV output. Use when auditing compliance, checking supply-chain
+  provenance, or scanning for third-party RPMs in RHOAI component images.
+allowed-tools: Bash
+user-invocable: true
+argument-hint: "<image_url_or_-f_input_file> [tag1 tag2 ...] | -l"
+metadata:
+  author: ODH
+  version: "1.0"
+  tags: compliance, rpms, container-images, audit
+---
+
+# Non-Red Hat RPMs
+
+Identify non-Red Hat-signed RPM packages in container images or on the local
+machine for compliance and supply-chain auditing.
+
+## Agent Instructions
+
+### Local vs container scan
+
+If the user asks to scan "this machine", "the host", "localhost", or similar,
+run the script with `-l`. No image URL, tags, or network access are needed:
+
+```bash
+./scripts/find_non_redhat_rpms.sh -l
+```
+
+For container image scans, follow the sections below.
+
+### Image URL defaults
+
+When the user requests a scan of an image without specifying the full URL:
+
+- **Default registry**: `quay.io`
+- **Default repositories** (in priority order): `rhoai`, then `opendatahub`
+- Try `quay.io/rhoai/<image>` first. If the image is not found there, try
+  `quay.io/opendatahub/<image>`.
+- If the user provides a registry (e.g. `registry.redhat.io`) or repository
+  (e.g. `opendatahub`), use those instead of the defaults.
+
+The script automatically resolves component names: if a repository is not
+found, it tries appending `-rhel9` (e.g. `odh-dashboard` resolves to
+`odh-dashboard-rhel9`). Pass the user's input as-is and let the script
+handle the resolution.
+
+For example, if the user says "scan odh-dashboard", run the script against
+`quay.io/rhoai/odh-dashboard`. The script will find that the repo doesn't
+exist and automatically try `quay.io/rhoai/odh-dashboard-rhel9`.
+If `quay.io/rhoai/` fails entirely, try `quay.io/opendatahub/` as the
+repository.
+
+### Large image confirmation
+
+The script always displays the compressed image size before pulling. For
+images exceeding 1 GB it prints a `WARNING:` line to stderr.
+
+When the tag is known before running the script, pre-check the size to
+decide whether to ask the user first:
+
+```bash
+skopeo inspect --override-arch amd64 "docker://<image>:<tag>" | jq '[.LayersData[].Size] | add'
+```
+
+If the total exceeds 1 GB (1073741824 bytes), **stop and ask the user for
+confirmation in the chat** before proceeding. Only run the script with `-y`
+after the user confirms. Do not repeat the size in your response — the
+script already displays it in its output.
+
+### Tag selection
+
+When the user does not specify a tag, discover available tags before running
+the script so you can offer a choice:
+
+```bash
+skopeo list-tags "docker://<image>" | jq -r '.Tags[]' \
+  | grep -E '^rhoai-[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$' | sort -V
+```
+
+If there are multiple release tags (stable and/or early access), present
+them to the user and let them pick which tag to scan. Show the highest
+stable tag and the highest EA tag as the recommended options, for example:
+
+> Available tags for odh-dashboard-rhel9:
+> - rhoai-3.4 (stable)
+> - rhoai-3.5-ea.2 (early access)
+>
+> Which tag would you like to scan?
+
+If the user does not have a preference, default to the highest version —
+preferring a stable tag over an early access tag at the same version.
+Then run the script with the chosen tag as a positional argument.
+
+### Multi-image scans
+
+When scanning multiple images, batch tag-discovery and size-check commands
+into a **single shell call** using a loop (with `&` / `wait` for
+parallelism). This avoids prompting the user to approve a separate custom
+command for every image:
+
+```bash
+for img in img-a img-b img-c; do
+  (skopeo list-tags "docker://quay.io/rhoai/${img}" 2>/dev/null \
+    | jq -r '.Tags[]' \
+    | grep -E '^rhoai-[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$' | sort -V \
+    | awk -v name="$img" '{print name": "$0}') &
+done
+wait
+```
+
+The same approach applies to size pre-checks — one shell call, one
+approval.
+
+### Results presentation
+
+Always present scan results as a **markdown table**, never as plain-text
+sentences. Include every scanned image as a row, even when the result is
+"clean". Example:
+
+```markdown
+| Image | Tag | Arch | Non-RH pkgs | Details |
+|-------|-----|------|-------------|---------|
+| odh-dashboard-rhel9 | rhoai-3.4 | amd64 | 0 | Clean |
+| odh-vllm-rhel9 | rhoai-3.5-ea.2 | amd64 | 3 | pkg-a, pkg-b, pkg-c |
+```
+
+## How It Works
+
+The script supports two modes:
+
+- **Container mode** (default): Pulls each image for every combination of
+  release tag and CPU architecture, runs `rpm -qai` inside the container to
+  extract package signing info, then filters out packages signed with the Red
+  Hat GPG key.
+- **Local mode** (`-l`): Runs `rpm -qai` directly on the host machine. No
+  container runtime or network access is required.
+
+In both modes the remaining non-Red Hat packages are emitted as CSV rows to
+stdout. Progress and diagnostics are printed to stderr, so the CSV output can
+be redirected or piped cleanly.
+
+## Usage
+
+Run the script from this skill's directory:
+
+```bash
+./scripts/find_non_redhat_rpms.sh -h
+```
+
+Scan the local machine:
+
+```bash
+./scripts/find_non_redhat_rpms.sh -l > results.csv
+```
+
+Quick scan of a single image (amd64, latest tag):
+
+```bash
+./scripts/find_non_redhat_rpms.sh quay.io/rhoai/odh-vllm-rocm-rhel9 > results.csv
+```
+
+Scan specific release tags:
+
+```bash
+./scripts/find_non_redhat_rpms.sh quay.io/rhoai/odh-vllm-rocm-rhel9 rhoai-3.4 rhoai-3.5-ea.1 > results.csv
+```
+
+Scan all supported architectures:
+
+```bash
+ARCHS="amd64 arm64 s390x ppc64le" ./scripts/find_non_redhat_rpms.sh quay.io/rhoai/odh-vllm-rocm-rhel9 > results.csv
+```
+
+Full matrix -- all architectures and multiple tags:
+
+```bash
+ARCHS="amd64 arm64 s390x ppc64le" ./scripts/find_non_redhat_rpms.sh quay.io/rhoai/odh-vllm-rocm-rhel9 rhoai-3.4 rhoai-3.5-ea.1 > results.csv
+```
+
+Multiple images from a file with custom tags:
+
+```bash
+./scripts/find_non_redhat_rpms.sh -f images.input rhoai-3.4 rhoai-3.5-ea.1 > results.csv
+```
+
+Append to an existing CSV (suppress header with `-H`):
+
+```bash
+./scripts/find_non_redhat_rpms.sh -H quay.io/rhoai/odh-vllm-gaudi-rhel9 >> results.csv
+```
+
+Run `-h` to see all options, environment variable overrides, and defaults.
+
+## Input File Format
+
+One image URL per line (without tag). Lines starting with `#` and blank lines
+are ignored.
+
+## Output Format
+
+CSV with header row:
+
+```text
+tag,arch,image_name,image_ref,pkg_name,key_id
+```
+
+| Column | Description |
+|--------|-------------|
+| tag | Release tag used (e.g. `rhoai-3.4`) |
+| arch | CPU architecture (e.g. `amd64`) |
+| image_name | Short image name (last path segment) |
+| image_ref | Full image reference with digest |
+| pkg_name | RPM package name |
+| key_id | GPG key ID that signed the package, or `(none)` |
+
+## Gotchas
+
+- On Fedora hosts, **all** packages will be flagged because the default
+  `REDHAT_KEY` matches the RHEL GPG key, not the Fedora signing key. This is
+  expected. Set `REDHAT_KEY` to the Fedora key if scanning a Fedora machine
+  for non-Fedora packages.
+- `gpg-pubkey` entries with key ID `(none)` are RPM-internal placeholders,
+  not real third-party software. They appear in virtually every image.
+- The `-l` flag ignores `ARCHS`, tags, and all container-related options.
+  Do not combine `-l` with image URLs.
+- Large images (>1 GB) prompt for confirmation in interactive mode. When
+  running from an AI agent, always pass `-y` to avoid hanging on a TTY
+  prompt.
+
+## Prerequisites
+
+- **Local mode** (`-l`): `rpm`
+- **Container mode**: `podman`, `skopeo`, `jq`, network access to the
+  container registry, and sufficient disk space for pulling images (cleaned
+  up after each tag)

--- a/helpers/skills/non-redhat-rpms/SKILL.md
+++ b/helpers/skills/non-redhat-rpms/SKILL.md
@@ -93,9 +93,13 @@ stable tag and the highest EA tag as the recommended options, for example:
 >
 > Which tag would you like to scan?
 
-If the user does not have a preference, default to the highest version —
-preferring a stable tag over an early access tag at the same version.
-Then run the script with the chosen tag as a positional argument.
+If the user does not have a preference, default to the most recent tag
+-- typically the highest-version early access tag (e.g. `rhoai-3.5-ea.2`
+over `rhoai-3.4`), since compliance scans are usually run against the
+newest, not-yet-released builds. The script's `discover_tags` already
+selects the highest version, preferring stable over EA only within the
+same version. Then run the script with the chosen tag as a positional
+argument.
 
 ### Multi-image scans
 
@@ -116,6 +120,17 @@ wait
 
 The same approach applies to size pre-checks — one shell call, one
 approval.
+
+For the actual scan, use the script's built-in parallelism with `-q`
+(quiet mode suppresses podman progress bars) and `PARALLEL=N`:
+
+```bash
+PARALLEL=4 ./scripts/find_non_redhat_rpms.sh -q -y -f images.input rhoai-3.5-ea.2
+```
+
+Each image is processed in its own subshell with isolated output files,
+so results are clean and not interleaved. Always use `-q` with
+`PARALLEL` to avoid garbled terminal output from concurrent podman pulls.
 
 ### Results presentation
 
@@ -193,6 +208,12 @@ Append to an existing CSV (suppress header with `-H`):
 
 ```bash
 ./scripts/find_non_redhat_rpms.sh -H quay.io/rhoai/odh-vllm-gaudi-rhel9 >> results.csv
+```
+
+Batch scan from input file with 4 parallel workers (quiet mode):
+
+```bash
+PARALLEL=4 ./scripts/find_non_redhat_rpms.sh -q -y -f images.input rhoai-3.5-ea.2 > results.csv
 ```
 
 Run `-h` to see all options, environment variable overrides, and defaults.

--- a/helpers/skills/non-redhat-rpms/scripts/find_non_redhat_rpms.sh
+++ b/helpers/skills/non-redhat-rpms/scripts/find_non_redhat_rpms.sh
@@ -4,32 +4,37 @@ set -euo pipefail
 STORAGE_ROOT=""
 NO_HEADER=false
 LOCAL_SCAN=false
+QUIET=false
+INPUT_FILE=""
 
 : "${REDHAT_KEY:=199e2f91fd431d51}"
 : "${ARCHS:=amd64}"
 : "${DEFAULT_TAGS:=latest}"
 : "${SIZE_WARN_MB:=1024}"
 : "${AUTO_CONFIRM:=false}"
+: "${PARALLEL:=1}"
 
 usage() {
     cat >&2 <<EOF
-Usage: $0 [-s <storage_path>] [-H] [-y] <image_url> [tag1 tag2 ...]
-       $0 [-s <storage_path>] [-H] [-y] -f <input_file> [tag1 tag2 ...]
+Usage: $0 [-s <storage_path>] [-H] [-y] [-q] <image_url> [tag1 tag2 ...]
+       $0 [-s <storage_path>] [-H] [-y] [-q] -f <input_file> [tag1 tag2 ...]
        $0 [-H] -l
 
 Extract non-Red Hat-signed RPMs from container images or the local machine.
 Images larger than ${SIZE_WARN_MB}MB trigger a size warning before pulling.
 
 Options:
+  -f <file>  Read image URLs from file (one per line, # for comments)
   -h         Show this help message
   -l         Scan the local machine instead of a container image
+  -q         Quiet mode: suppress podman progress bars (useful for parallel
+             runs or agent-driven scans)
   -s <path>  Podman storage root (passed as --root to podman)
   -H         Suppress CSV header (useful when appending to existing output)
   -y         Auto-confirm large image pulls (skip size warning prompt)
 
 Arguments:
   image_url   Container image URL without tag (e.g. quay.io/rhoai/odh-vllm-rocm-rhel9)
-  -f <file>   Read image URLs from file (one per line, # for comments)
   tag1 ...    Release tags to check (appended to image URL as :tag)
 
 Environment variables:
@@ -43,6 +48,7 @@ Environment variables:
                 (default: 1024)
   AUTO_CONFIRM    Set to 'true' to skip size warning prompts
                 (default: false)
+  PARALLEL        Max concurrent image scans (default: 1, sequential)
 
 Image resolution:
   If the repository is not found, the script also tries appending -rhel9
@@ -75,14 +81,19 @@ Examples:
 
   # Full matrix — all architectures and multiple tags:
   ARCHS="amd64 arm64 s390x ppc64le" $0 quay.io/rhoai/odh-vllm-rocm-rhel9 rhoai-3.4 rhoai-3.5
+
+  # Batch scan from input file with 4 parallel workers (quiet mode):
+  PARALLEL=4 $0 -q -y -f images.input rhoai-3.5-ea.2 > results.csv
 EOF
     exit "${1:-1}"
 }
 
-while getopts ":hls:Hy" opt; do
+while getopts ":f:hlqs:Hy" opt; do
     case $opt in
+        f) INPUT_FILE="$OPTARG" ;;
         h) usage 0 ;;
         l) LOCAL_SCAN=true ;;
+        q) QUIET=true ;;
         s) STORAGE_ROOT="$OPTARG" ;;
         H) NO_HEADER=true ;;
         y) AUTO_CONFIRM=true ;;
@@ -115,7 +126,7 @@ scan_local() {
     echo "[local] Extracting RPM info ..." >&2
 
     local raw_output
-    raw_output=$(rpm -qai \
+    raw_output=$(LC_ALL=C rpm -qai \
         | awk '/^Name/{name=$3} /^Signature/{if($0~/Key ID/){kid=$NF}else{kid="(none)"}; print name" "kid}')
 
     local total_pkgs
@@ -154,7 +165,7 @@ for cmd in podman skopeo jq; do
     fi
 done
 
-if [ $# -lt 1 ]; then
+if [ $# -lt 1 ] && [ -z "$INPUT_FILE" ]; then
     usage
 fi
 
@@ -170,26 +181,20 @@ read -ra ARCH_ARRAY <<< "$ARCHS"
 read -ra DEFAULT_TAG_ARRAY <<< "$DEFAULT_TAGS"
 
 IMAGES=()
-if [ "$1" = "-f" ]; then
-    if [ $# -lt 2 ]; then
-        echo "Error: -f requires a file argument." >&2
-        usage
-    fi
-    input_file="$2"
-    if [ ! -f "$input_file" ]; then
-        echo "Error: input file not found: ${input_file}" >&2
+if [ -n "$INPUT_FILE" ]; then
+    if [ ! -f "$INPUT_FILE" ]; then
+        echo "Error: input file not found: ${INPUT_FILE}" >&2
         exit 1
     fi
-    if [ ! -r "$input_file" ]; then
-        echo "Error: input file not readable: ${input_file}" >&2
+    if [ ! -r "$INPUT_FILE" ]; then
+        echo "Error: input file not readable: ${INPUT_FILE}" >&2
         exit 1
     fi
-    shift 2
     while IFS= read -r line; do
         [[ -z "$line" || "$line" == \#* ]] && continue
         IMAGES+=("$line")
-    done < "$input_file"
-else
+    done < "$INPUT_FILE"
+elif [ $# -ge 1 ]; then
     IMAGES+=("$1")
     shift
 fi
@@ -345,7 +350,11 @@ scan_tag() {
             continue
         fi
         echo "[${image_name}/${tag}/${arch}] Pulling ..." >&2
-        if ! podman pull --platform "linux/${arch}" "${container_image}" >&2 2>&1; then
+        local -a pull_opts=(--platform "linux/${arch}")
+        if [ "$QUIET" = true ]; then
+            pull_opts+=(--quiet)
+        fi
+        if ! podman pull "${pull_opts[@]}" "${container_image}" >&2 2>&1; then
             echo "[${image_name}/${tag}/${arch}] Not available, skipping." >&2
             pull_failed=$((pull_failed + 1))
             continue
@@ -356,7 +365,7 @@ scan_tag() {
         echo "[${image_name}/${tag}/${arch}] Digest: ${image_digest}" >&2
 
         echo "[${image_name}/${tag}/${arch}] Extracting RPM info ..." >&2
-        raw_output=$(podman run --rm --platform "linux/${arch}" --entrypoint /bin/bash "${container_image}" -c 'rpm -qai | awk "/^Name/{name=\$3} /^Signature/{if(\$0~/Key ID/){kid=\$NF}else{kid=\"(none)\"}; print name\" \"kid}"')
+        raw_output=$(podman run --rm --platform "linux/${arch}" --entrypoint /bin/bash "${container_image}" -c 'LC_ALL=C rpm -qai | awk "/^Name/{name=\$3} /^Signature/{if(\$0~/Key ID/){kid=\$NF}else{kid=\"(none)\"}; print name\" \"kid}"')
 
         total_pkgs=$(echo "$raw_output" | wc -l)
         filtered_output=$(echo "$raw_output" | grep -vi "${REDHAT_KEY}" || true)
@@ -383,13 +392,15 @@ if [ "$NO_HEADER" = false ]; then
     echo "tag,arch,image_name,image_ref,pkg_name,key_id"
 fi
 
-for RAW_IMAGE in "${IMAGES[@]}"; do
+process_image() {
+    local RAW_IMAGE="$1" out_csv="$2" out_log="$3"
+    local IMAGE
     IMAGE=$(resolve_image "$RAW_IMAGE")
-    image_name="${IMAGE##*/}"
-    all_tags_failed=true
+    local image_name="${IMAGE##*/}"
+    local all_tags_failed=true
 
     for tag in "${TAGS[@]}"; do
-        pull_failures=0
+        local pull_failures=0
         scan_tag "$IMAGE" "$tag" || pull_failures=$?
         if [ "$pull_failures" -lt "${#ARCH_ARRAY[@]}" ]; then
             all_tags_failed=false
@@ -398,12 +409,53 @@ for RAW_IMAGE in "${IMAGES[@]}"; do
 
     if [ "$all_tags_failed" = true ] && [ "$USER_TAGS" = false ]; then
         echo "[${image_name}] Default tag(s) not available, auto-discovering tags ..." >&2
+        local discovered_tag
         discovered_tag=$(discover_tags "$IMAGE") || true
         if [ -n "$discovered_tag" ]; then
             scan_tag "$IMAGE" "$discovered_tag" || true
         fi
     fi
-done
+}
+
+if [ "$PARALLEL" -le 1 ]; then
+    for RAW_IMAGE in "${IMAGES[@]}"; do
+        process_image "$RAW_IMAGE" "" ""
+    done
+else
+    WORK_DIR=$(mktemp -d)
+    trap 'rm -rf "${WORK_DIR}"' EXIT
+    active=0
+    pids=()
+
+    for RAW_IMAGE in "${IMAGES[@]}"; do
+        img_slug="${RAW_IMAGE##*/}"
+        out_csv="${WORK_DIR}/${img_slug}.csv"
+        out_log="${WORK_DIR}/${img_slug}.log"
+
+        process_image "$RAW_IMAGE" "" "" >"$out_csv" 2>"$out_log" &
+        pids+=($!)
+        active=$((active + 1))
+
+        if [ "$active" -ge "$PARALLEL" ]; then
+            wait -n 2>/dev/null || true
+            active=$((active - 1))
+        fi
+    done
+
+    for pid in "${pids[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+
+    for RAW_IMAGE in "${IMAGES[@]}"; do
+        img_slug="${RAW_IMAGE##*/}"
+        if [ -s "${WORK_DIR}/${img_slug}.log" ]; then
+            cat "${WORK_DIR}/${img_slug}.log" >&2
+        fi
+        if [ -s "${WORK_DIR}/${img_slug}.csv" ]; then
+            cat "${WORK_DIR}/${img_slug}.csv"
+        fi
+    done
+fi
 
 ALL_ARCHS="amd64 arm64 s390x ppc64le"
 scanned="${ARCHS}"

--- a/helpers/skills/non-redhat-rpms/scripts/find_non_redhat_rpms.sh
+++ b/helpers/skills/non-redhat-rpms/scripts/find_non_redhat_rpms.sh
@@ -1,0 +1,428 @@
+#!/bin/bash
+set -euo pipefail
+
+STORAGE_ROOT=""
+NO_HEADER=false
+LOCAL_SCAN=false
+
+: "${REDHAT_KEY:=199e2f91fd431d51}"
+: "${ARCHS:=amd64}"
+: "${DEFAULT_TAGS:=latest}"
+: "${SIZE_WARN_MB:=1024}"
+: "${AUTO_CONFIRM:=false}"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [-s <storage_path>] [-H] [-y] <image_url> [tag1 tag2 ...]
+       $0 [-s <storage_path>] [-H] [-y] -f <input_file> [tag1 tag2 ...]
+       $0 [-H] -l
+
+Extract non-Red Hat-signed RPMs from container images or the local machine.
+Images larger than ${SIZE_WARN_MB}MB trigger a size warning before pulling.
+
+Options:
+  -h         Show this help message
+  -l         Scan the local machine instead of a container image
+  -s <path>  Podman storage root (passed as --root to podman)
+  -H         Suppress CSV header (useful when appending to existing output)
+  -y         Auto-confirm large image pulls (skip size warning prompt)
+
+Arguments:
+  image_url   Container image URL without tag (e.g. quay.io/rhoai/odh-vllm-rocm-rhel9)
+  -f <file>   Read image URLs from file (one per line, # for comments)
+  tag1 ...    Release tags to check (appended to image URL as :tag)
+
+Environment variables:
+  REDHAT_KEY    GPG key ID to identify Red Hat-signed packages
+              (default: 199e2f91fd431d51)
+  DEFAULT_TAGS    Space-separated release tags when none given on command line
+                (default: latest)
+  ARCHS           Space-separated architectures to pull
+                (default: amd64)
+  SIZE_WARN_MB    Warn before pulling images larger than this (in MB)
+                (default: 1024)
+  AUTO_CONFIRM    Set to 'true' to skip size warning prompts
+                (default: false)
+
+Image resolution:
+  If the repository is not found, the script also tries appending -rhel9
+  to the image name (e.g. odh-dashboard -> odh-dashboard-rhel9).
+
+Tag resolution (when no tags are given on the command line):
+  1. Try DEFAULT_TAGS (latest)
+  2. Auto-discover tags via skopeo: pick the highest stable rhoai-X.Y tag,
+     or the latest early access (EA) rhoai-* tag, or odh-pr-linux-x86-64
+
+Prerequisites:
+  Container mode: podman, skopeo, jq
+  Local mode (-l): rpm
+
+Examples:
+  # Scan the local machine:
+  $0 -l
+
+  # Quick scan (amd64, auto-discovers tag if latest unavailable):
+  $0 quay.io/rhoai/odh-vllm-rocm-rhel9
+
+  # Scan specific release tags:
+  $0 quay.io/rhoai/odh-vllm-rocm-rhel9 rhoai-3.4 rhoai-3.5
+
+  # Skip size warning prompts for large images:
+  $0 -y quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9
+
+  # Scan all supported architectures:
+  ARCHS="amd64 arm64 s390x ppc64le" $0 quay.io/rhoai/odh-vllm-rocm-rhel9
+
+  # Full matrix — all architectures and multiple tags:
+  ARCHS="amd64 arm64 s390x ppc64le" $0 quay.io/rhoai/odh-vllm-rocm-rhel9 rhoai-3.4 rhoai-3.5
+EOF
+    exit "${1:-1}"
+}
+
+while getopts ":hls:Hy" opt; do
+    case $opt in
+        h) usage 0 ;;
+        l) LOCAL_SCAN=true ;;
+        s) STORAGE_ROOT="$OPTARG" ;;
+        H) NO_HEADER=true ;;
+        y) AUTO_CONFIRM=true ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+host_arch() {
+    local machine
+    machine=$(uname -m)
+    case "$machine" in
+        x86_64)  echo "amd64" ;;
+        aarch64) echo "arm64" ;;
+        *)       echo "$machine" ;;
+    esac
+}
+
+scan_local() {
+    local hostname arch os_release
+    hostname=$(hostname -s)
+    arch=$(host_arch)
+    os_release="local"
+    if [ -f /etc/os-release ]; then
+        # shellcheck source=/dev/null
+        os_release=$(. /etc/os-release && echo "${ID:-linux}-${VERSION_ID:-unknown}")
+    fi
+
+    echo "[local] Scanning host: ${hostname} (${arch}, ${os_release})" >&2
+    echo "[local] Extracting RPM info ..." >&2
+
+    local raw_output
+    raw_output=$(rpm -qai \
+        | awk '/^Name/{name=$3} /^Signature/{if($0~/Key ID/){kid=$NF}else{kid="(none)"}; print name" "kid}')
+
+    local total_pkgs
+    total_pkgs=$(echo "$raw_output" | wc -l)
+    local filtered_output
+    filtered_output=$(echo "$raw_output" | grep -vi "${REDHAT_KEY}" || true)
+    if [ -z "$filtered_output" ]; then
+        echo "[local] All ${total_pkgs} packages are Red Hat-signed." >&2
+        return 0
+    fi
+    local filtered_pkgs
+    filtered_pkgs=$(echo "$filtered_output" | wc -l)
+    echo "[local] Found ${filtered_pkgs} non-Red Hat packages (out of ${total_pkgs} total)." >&2
+
+    while IFS=' ' read -r pkg_name key_id; do
+        echo "local,${arch},${hostname},${os_release},${pkg_name},${key_id}"
+    done <<< "$filtered_output"
+}
+
+if [ "$LOCAL_SCAN" = true ]; then
+    if ! command -v rpm >/dev/null 2>&1; then
+        echo "Error: rpm is not installed or not in PATH." >&2
+        exit 1
+    fi
+    if [ "$NO_HEADER" = false ]; then
+        echo "tag,arch,image_name,image_ref,pkg_name,key_id"
+    fi
+    scan_local
+    exit 0
+fi
+
+for cmd in podman skopeo jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: ${cmd} is not installed or not in PATH." >&2
+        exit 1
+    fi
+done
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+PODMAN_OPTS=()
+if [ -n "$STORAGE_ROOT" ]; then
+    PODMAN_OPTS+=(--root "$STORAGE_ROOT")
+    echo ">>> Using podman storage: ${STORAGE_ROOT}" >&2
+fi
+
+podman() { command podman "${PODMAN_OPTS[@]}" "$@"; }
+
+read -ra ARCH_ARRAY <<< "$ARCHS"
+read -ra DEFAULT_TAG_ARRAY <<< "$DEFAULT_TAGS"
+
+IMAGES=()
+if [ "$1" = "-f" ]; then
+    if [ $# -lt 2 ]; then
+        echo "Error: -f requires a file argument." >&2
+        usage
+    fi
+    input_file="$2"
+    if [ ! -f "$input_file" ]; then
+        echo "Error: input file not found: ${input_file}" >&2
+        exit 1
+    fi
+    if [ ! -r "$input_file" ]; then
+        echo "Error: input file not readable: ${input_file}" >&2
+        exit 1
+    fi
+    shift 2
+    while IFS= read -r line; do
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        IMAGES+=("$line")
+    done < "$input_file"
+else
+    IMAGES+=("$1")
+    shift
+fi
+
+if [ ${#IMAGES[@]} -eq 0 ]; then
+    echo "Error: no images to process (file may be empty or all lines commented)." >&2
+    exit 1
+fi
+
+USER_TAGS=false
+if [ $# -gt 0 ]; then
+    TAGS=("$@")
+    USER_TAGS=true
+else
+    TAGS=("${DEFAULT_TAG_ARRAY[@]}")
+fi
+
+repo_exists() {
+    local image="$1"
+    local err
+    err=$(skopeo inspect --raw "docker://${image}:latest" 2>&1 1>/dev/null) || true
+    if echo "$err" | grep -q "repository not found"; then
+        return 1
+    fi
+    return 0
+}
+
+resolve_image() {
+    local image="$1"
+    local image_name="${image##*/}"
+    if repo_exists "$image"; then
+        echo "$image"
+        return 0
+    fi
+    if [[ "$image" != *-rhel9 ]]; then
+        local alt="${image}-rhel9"
+        echo "[${image_name}] Repository not found, trying ${alt##*/} ..." >&2
+        if repo_exists "$alt"; then
+            echo "[${image_name}] Resolved to ${alt##*/}" >&2
+            echo "$alt"
+            return 0
+        fi
+    fi
+    echo "[${image_name}] Repository not found." >&2
+    echo "$image"
+}
+
+discover_tags() {
+    local image="$1"
+    local image_name="${image##*/}"
+    echo "[${image_name}] Discovering tags via skopeo ..." >&2
+    local all_repo_tags
+    all_repo_tags=$(skopeo list-tags "docker://${image}" 2>/dev/null \
+        | jq -r '.Tags[]') || true
+    if [ -z "$all_repo_tags" ]; then
+        echo "[${image_name}] Could not list tags (repository not found?)." >&2
+        return 1
+    fi
+
+    local release_tags
+    release_tags=$(echo "$all_repo_tags" \
+        | grep -E '^rhoai-[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$' \
+        | sort -V || true)
+    if [ -n "$release_tags" ]; then
+        local count
+        count=$(echo "$release_tags" | wc -l)
+        echo "[${image_name}] Found ${count} rhoai-* release tag(s)." >&2
+
+        local highest_version
+        highest_version=$(echo "$release_tags" \
+            | grep -oE '^rhoai-[0-9]+\.[0-9]+' \
+            | sort -V \
+            | tail -1) || true
+
+        if [ -n "$highest_version" ]; then
+            if echo "$release_tags" | grep -qx "$highest_version"; then
+                echo "[${image_name}] Using latest stable tag: ${highest_version}" >&2
+                echo "$highest_version"
+                return 0
+            fi
+
+            local ea_tag
+            ea_tag=$(echo "$release_tags" \
+                | grep -E "^${highest_version}-" \
+                | sort -V \
+                | tail -1 || true)
+            if [ -n "$ea_tag" ]; then
+                echo "[${image_name}] No stable ${highest_version}, using early access: ${ea_tag}" >&2
+                echo "$ea_tag"
+                return 0
+            fi
+        fi
+
+        local latest_tag
+        latest_tag=$(echo "$release_tags" | tail -1)
+        echo "[${image_name}] Using latest available: ${latest_tag}" >&2
+        echo "$latest_tag"
+        return 0
+    fi
+
+    if echo "$all_repo_tags" | grep -qx 'odh-pr-linux-x86-64'; then
+        echo "[${image_name}] No rhoai-* tags found, using odh-pr-linux-x86-64." >&2
+        echo "odh-pr-linux-x86-64"
+        return 0
+    fi
+
+    echo "[${image_name}] No suitable tags found." >&2
+    return 1
+}
+
+check_image_size() {
+    local image="$1" tag="$2" arch="$3"
+    local image_name="${image##*/}"
+    local container_image="${image}:${tag}"
+    local size_bytes
+    size_bytes=$(skopeo inspect --override-arch "$arch" "docker://${container_image}" 2>/dev/null \
+        | jq '[.LayersData[].Size] | add // 0') || true
+    if [ -z "$size_bytes" ] || [ "$size_bytes" = "0" ] || [ "$size_bytes" = "null" ]; then
+        echo "[${image_name}/${tag}/${arch}] Image size: unknown" >&2
+        return 0
+    fi
+    local size_mb=$((size_bytes / 1024 / 1024))
+    if [ "$size_mb" -ge "$SIZE_WARN_MB" ]; then
+        echo "WARNING: ${container_image} (${arch}) is ~${size_mb}MB (compressed)." >&2
+        if [ "$AUTO_CONFIRM" = true ]; then
+            echo "  Auto-confirmed (-y flag), proceeding." >&2
+            return 0
+        fi
+        if [ -t 0 ]; then
+            read -r -p "  Continue pulling? [y/N] " answer </dev/tty
+            case "$answer" in
+                [yY]*) return 0 ;;
+                *) echo "  Skipping." >&2; return 1 ;;
+            esac
+        else
+            echo "  Non-interactive mode, proceeding anyway." >&2
+        fi
+    else
+        echo "[${image_name}/${tag}/${arch}] Image size: ~${size_mb}MB (compressed)" >&2
+    fi
+    return 0
+}
+
+scan_tag() {
+    local image="$1" tag="$2"
+    local image_name="${image##*/}"
+    local container_image="${image}:${tag}"
+    local pull_failed=0
+
+    for arch in "${ARCH_ARRAY[@]}"; do
+        if ! check_image_size "$image" "$tag" "$arch"; then
+            pull_failed=$((pull_failed + 1))
+            continue
+        fi
+        echo "[${image_name}/${tag}/${arch}] Pulling ..." >&2
+        if ! podman pull --platform "linux/${arch}" "${container_image}" >&2 2>&1; then
+            echo "[${image_name}/${tag}/${arch}] Not available, skipping." >&2
+            pull_failed=$((pull_failed + 1))
+            continue
+        fi
+
+        image_digest=$(podman inspect --format '{{.Digest}}' "${container_image}")
+        local image_ref="${image}@${image_digest}"
+        echo "[${image_name}/${tag}/${arch}] Digest: ${image_digest}" >&2
+
+        echo "[${image_name}/${tag}/${arch}] Extracting RPM info ..." >&2
+        raw_output=$(podman run --rm --platform "linux/${arch}" --entrypoint /bin/bash "${container_image}" -c 'rpm -qai | awk "/^Name/{name=\$3} /^Signature/{if(\$0~/Key ID/){kid=\$NF}else{kid=\"(none)\"}; print name\" \"kid}"')
+
+        total_pkgs=$(echo "$raw_output" | wc -l)
+        filtered_output=$(echo "$raw_output" | grep -vi "${REDHAT_KEY}" || true)
+        if [ -z "$filtered_output" ]; then
+            echo "[${image_name}/${tag}/${arch}] All ${total_pkgs} packages are Red Hat-signed." >&2
+            continue
+        fi
+        filtered_pkgs=$(echo "$filtered_output" | wc -l)
+        echo "[${image_name}/${tag}/${arch}] Found ${filtered_pkgs} non-Red Hat packages (out of ${total_pkgs} total)." >&2
+
+        while IFS=' ' read -r pkg_name key_id; do
+            echo "${tag},${arch},${image_name},${image_ref},${pkg_name},${key_id}"
+        done <<< "$filtered_output"
+    done
+
+    echo "[${image_name}/${tag}] Cleaning up ..." >&2
+    podman rm -f "$(podman ps -a -q --filter "ancestor=${container_image}")" 2>/dev/null || true
+    podman rmi -f "${container_image}" >/dev/null 2>&1 || true
+
+    return "$pull_failed"
+}
+
+if [ "$NO_HEADER" = false ]; then
+    echo "tag,arch,image_name,image_ref,pkg_name,key_id"
+fi
+
+for RAW_IMAGE in "${IMAGES[@]}"; do
+    IMAGE=$(resolve_image "$RAW_IMAGE")
+    image_name="${IMAGE##*/}"
+    all_tags_failed=true
+
+    for tag in "${TAGS[@]}"; do
+        pull_failures=0
+        scan_tag "$IMAGE" "$tag" || pull_failures=$?
+        if [ "$pull_failures" -lt "${#ARCH_ARRAY[@]}" ]; then
+            all_tags_failed=false
+        fi
+    done
+
+    if [ "$all_tags_failed" = true ] && [ "$USER_TAGS" = false ]; then
+        echo "[${image_name}] Default tag(s) not available, auto-discovering tags ..." >&2
+        discovered_tag=$(discover_tags "$IMAGE") || true
+        if [ -n "$discovered_tag" ]; then
+            scan_tag "$IMAGE" "$discovered_tag" || true
+        fi
+    fi
+done
+
+ALL_ARCHS="amd64 arm64 s390x ppc64le"
+scanned="${ARCHS}"
+not_scanned=""
+for a in $ALL_ARCHS; do
+    found=false
+    for s in ${scanned}; do
+        if [ "$a" = "$s" ]; then found=true; break; fi
+    done
+    if [ "$found" = false ]; then
+        not_scanned="${not_scanned:+${not_scanned} }${a}"
+    fi
+done
+
+echo "" >&2
+echo "=== Scan complete ===" >&2
+echo "Architectures scanned: ${scanned}" >&2
+if [ -n "$not_scanned" ]; then
+    echo "WARNING: architectures NOT scanned: ${not_scanned}" >&2
+    echo "  Other architectures of the same image:tag may contain different packages." >&2
+    echo "  To scan all architectures, re-run with: ARCHS=\"${ALL_ARCHS}\"" >&2
+fi


### PR DESCRIPTION
# Pull Request Description
Introduces a new skill to identify non-Red Hat RPM packages in container images or on local machines. This skill extracts RPM signing metadata and generates CSV output for packages not signed with the Red Hat GPG key, aiding in compliance auditing and supply-chain tracking.


## Summary
Adds the `non-redhat-rpms` skill, which scans container images or the local host for RPM packages not signed with the Red Hat GPG key. The scan results are emitted as CSV, making it straightforward to pipe into downstream compliance tooling. A new "Compliance" category is also introduced in `categories.yaml` for this and future compliance-oriented tools.

## Type of Contribution
<!-- Check all that apply -->
- [ ] 📝 New command
- [x] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [ ] 🏗️ Infrastructure/tooling
- [x] 📋 New category addition

## Changes Made
- **`helpers/skills/non-redhat-rpms/SKILL.md`** -- Skill definition with agent instructions covering image URL defaults (`quay.io/rhoai`), automatic `-rhel9` suffix resolution, tag discovery, large-image confirmation workflow, multi-image parallel scanning, and results-presentation guidelines (markdown table).
- **`helpers/skills/non-redhat-rpms/scripts/find_non_redhat_rpms.sh`** -- Bash script implementing two modes: container mode (pulls images via `podman`, inspects RPM signatures) and local mode (`-l`, runs `rpm -qai` on the host). Supports multi-arch pulls, parallel workers (`PARALLEL=N`), quiet mode (`-q`), size warnings for images >1 GB, auto tag discovery via `skopeo`, and CSV output.
- **`categories.yaml`** -- Added new "Compliance" category containing `non-redhat-rpms`.

## Tool Details

### Skill
- **Skill name**: `non-redhat-rpms`
- **Primary use case**: Identify non-Red Hat-signed RPM packages in container images or on the local machine for compliance and supply-chain auditing.
- **Dependencies required**: Container mode -- `podman`, `skopeo`, `jq`, and network access to the container registry. Local mode (`-l`) -- `rpm` only.

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [x] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
<!-- Check all that were tested -->
- [ ] Claude Code: Tested commands/skills/agents integration
- [x] Cursor AI: Tested tool integration (if applicable)
- [ ] Gemini: Created Gem in Gemini platform and verified sharing link works (if applicable)

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
<!-- List any special requirements -->
- Python scripts use proper shebang lines and PEP 723 metadata if needed
- All scripts are executable (chmod +x)
- No undocumented external dependencies

## Additional Notes
- On Fedora hosts, local mode (`-l`) flags all packages because the default `REDHAT_KEY` matches the RHEL GPG key, not the Fedora signing key. This is expected and documented in the Gotchas section of the SKILL.md.
- `gpg-pubkey` entries with key ID `(none)` are RPM-internal placeholders and appear in virtually every image; they are not real third-party software.
- When running from an AI agent, always pass `-y` to the script to avoid hanging on interactive size-warning prompts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Compliance category for compliance-related tools and utilities.
  * Added non-redhat-rpms scanning tool to identify packages with non-standard signatures in container images and local systems.

* **Documentation**
  * Added comprehensive user guide for the non-redhat-rpms tool, including usage modes, output formats, and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->