### PR TITLE
refactor: migrate commands to skills

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,11 +20,6 @@ reviews:
         traversal) on prompt text that describes what an AI agent should do —
         these are instructions, not attack surfaces. Only flag CWEs on actual
         executable scripts referenced by the skill.
-    - path: "helpers/commands/*.md"
-      instructions: >-
-        These are command prompt files for AI agents. Same review priorities
-        as SKILL.md: focus on correctness, consistency, and markdown quality.
-        Do NOT flag CWE vulnerabilities on prompt instructions.
     - path: "helpers/skills/**/scripts/**"
       instructions: >-
         These are executable scripts. Apply full security review including

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -7,14 +7,6 @@ custom-rules:
   - .skillsaw-custom.py
 
 rules:
-  command-sections:
-    enabled: true
-    severity: warning
-
-  command-name-format:
-    enabled: true
-    severity: warning
-
   plugins-doc-up-to-date:
     enabled: true
     severity: error
@@ -27,9 +19,6 @@ rules:
     enabled: true
     severity: warning
     limits:
-      command:
-        warn: 3000
-        error: 6000
       agent:
         warn: 5000
         error: 10000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,8 @@ This repository serves as a collaborative marketplace for AI automation tools, p
 
 ## Repository Purpose
 
-The odh-ai-helpers repository hosts collections of four distinct tool types:
+The odh-ai-helpers repository hosts collections of three distinct tool types:
 - **Skills**: Standardized capabilities using agentskills.io format, compatible with Claude Code and Cursor
-- **Commands**: Atomic, executable actions for immediate functionality
 - **Agents**: Specialized AI entities for complex, multi-step workflows and analysis
 - **Gemini Gems**: Conversational AI assistants optimized for specific domains
 
@@ -18,11 +17,6 @@ This enables teams to automate repetitive tasks, integrate with development tool
 Standardized capabilities that work across multiple AI platforms using the agentskills.io specification. Skills provide reusable functionality with cross-platform compatibility.
 
 **→ Located in [helpers/skills/](helpers/skills/) directory**
-
-### Commands
-Atomic, executable actions that provide immediate functionality. Commands are designed for quick, specific tasks and can be invoked directly by AI agents.
-
-**→ Located in [helpers/commands/](helpers/commands/) directory**
 
 ### Agents
 Specialized AI entities capable of complex reasoning and multi-step workflows. Agents maintain context and can execute sophisticated analysis within their domain of expertise.
@@ -38,18 +32,14 @@ Conversational AI assistants created within Google's Gemini platform. Each Gem i
 
 ### Claude Code
 - **Skills**: Available through marketplace plugin entries
-- **Commands**: Available through marketplace plugin entries
 - **Agents**: Available as sub-agents through marketplace plugin entries
-
 
 ### OpenCode.ai
 - **Skills**: Compatible as OpenCode skills in ~/.config/opencode/skills/
-- **Commands**: Compatible as OpenCode commands in ~/.config/opencode/commands/
 - **Agents**: Not currently compatible due to format differences
 
 ### Cursor AI
 - **Skills**: Compatible through agentskills.io format
-- **Commands**: Can be adapted for Cursor command structure
 - **Agents**: Can be used as specialized workflow guides
 
 ## How to Create New Tools
@@ -139,8 +129,8 @@ These rules prevent the most common review findings. Follow them when generating
 - Pin GitHub Actions to full 40-character commit SHAs, not version tags.
 - Pin inline script dependencies to specific versions.
 
-### Skills and Commands
-- Run `make update` after creating or modifying any skill, command, or agent.
+### Skills
+- Run `make update` after creating or modifying any skill or agent.
 - `allowed_tools` in frontmatter must follow least-privilege — only list tools the skill actually uses.
 - Never reference real people by name (see ETHICS.md).
 - Use team/org identifiers in `metadata.author`, not personal names.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,6 @@ This is the most common type of contribution. The repository hosts four tool typ
 | Type | Location | Format |
 |------|----------|--------|
 | **Skills** | `helpers/skills/<name>/` | Directory with `SKILL.md` and optional `scripts/` |
-| **Commands** | `helpers/commands/` | Single Markdown file |
 | **Agents** | `helpers/agents/` | Single Markdown file |
 | **Gemini Gems** | `helpers/gems/` | Entry in `gems.yaml` |
 
@@ -75,14 +74,14 @@ make lint      # Run all linters and validation checks
 Run `make update` first and **commit any generated changes** before running `make lint`. The `lint` target re-runs `make update` internally and will fail if there are uncommitted diffs.
 
 The `lint` target runs:
-- **[skillsaw](https://github.com/stbenjam/skillsaw)** -- validates plugin structure, skills, and commands
+- **[skillsaw](https://github.com/stbenjam/skillsaw)** -- validates plugin structure and skills
 - **ruff** -- checks and formats Python code
 - **shellcheck** -- lints shell scripts
 - Verifies that `make update` produces no uncommitted changes
 
 ### Test Locally (Claude Code)
 
-To test a skill or command with Claude Code before submitting:
+To test a skill with Claude Code before submitting:
 
 1. Open `claude`
 2. Run `/plugin marketplace add ./`
@@ -127,16 +126,6 @@ Common optional fields:
 | `metadata` | Block for `author`, `version`, and `tags` |
 
 Study existing skills in `helpers/skills/` for examples of structure and patterns.
-
-### Commands
-
-Commands are single Markdown files in `helpers/commands/`:
-
-```text
-helpers/commands/my-command.md
-```
-
-See `helpers/commands/hello-world-echo.md` for an example.
 
 ### Agents
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Want to work on an issue? Comment `/assign` on it to assign yourself.
 This repository is made for collaboration. We highly welcome contributions.
 
 For skills, check out the `helpers/skills/` directory for examples.
-For commands, check the `helpers/commands/` directory, and for agents see the `helpers/agents/` directory.
+For agents, see the `helpers/agents/` directory.
 Using AI code assistant itself to develop the tools is highly encouraged.
 
 ### Adding New Tools
@@ -35,9 +35,8 @@ Using AI code assistant itself to develop the tools is highly encouraged.
 When contributing new tools:
 
 1. **Skills**: Add to the `helpers/skills/` directory following the agentskills.io format
-2. **Commands**: Add to the `helpers/commands/` directory as Markdown files
-3. **Agents**: Add to the `helpers/agents/` directory with appropriate documentation
-4. **Gemini Gems**: Add to the `helpers/gems/` directory
+2. **Agents**: Add to the `helpers/agents/` directory with appropriate documentation
+3. **Gemini Gems**: Add to the `helpers/gems/` directory
 
 Once you have added the tool, you'd have to run have to run `make update` in order to generate the website data.
 Then you should git commit your change and after than running `make lint` would run local tests to validate the syntax.
@@ -289,7 +288,7 @@ cursor-container() {
 
 [OpenCode.ai](https://opencode.ai) is an open-source AI coding assistant that supports custom skills and commands. Our helpers can be integrated as OpenCode skills and commands to enhance your development workflow.
 
-**Note**: OpenCode.ai agents are not currently compatible due to format differences. Only skills and commands are supported at this time.
+**Note**: OpenCode.ai agents are not currently compatible due to format differences. Only skills are supported at this time.
 
 ### Setup
 
@@ -301,9 +300,8 @@ cursor-container() {
 
 2. **Install globally:**
    ```bash
-   mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands
+   mkdir -p ~/.config/opencode/skills
    ln -sf $(pwd)/helpers/skills/* ~/.config/opencode/skills/
-   ln -sf $(pwd)/helpers/commands/* ~/.config/opencode/commands/
    ```
 
 These helpers are available when loading the odh-ai-helpers plugin from the marketplace as instructed above.
@@ -325,7 +323,7 @@ make lint
 
 This runs the following checks in order:
 
-1. **[skillsaw](https://github.com/stbenjam/skillsaw)** — lints skills, plugins, and commands against the agentskills.io spec with content intelligence
+1. **[skillsaw](https://github.com/stbenjam/skillsaw)** — lints skills and plugins against the agentskills.io spec with content intelligence
 2. **[ruff](https://docs.astral.sh/ruff/) check** — Python syntax and style errors
 3. **ruff format --check** — Python formatting consistency
 4. **[shellcheck](https://www.shellcheck.net/)** — shell script analysis for all `*.sh` files

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,6 @@ python3 scripts/build-website.py
 
 This extracts information from:
 - `categories.yaml` - Centralized category registry
-- `helpers/commands/*.md` - Command definitions
 - `helpers/skills/*/SKILL.md` - Skill definitions
 - `helpers/agents/*.md` - Agent definitions
 - `helpers/gems/gems.yaml` - Gemini Gems definitions
@@ -41,7 +40,7 @@ The site will be available at: `https://opendatahub-io.github.io/ai-helpers/`
 
 ## Updating
 
-When plugins or commands are added/modified:
+When tools are added/modified:
 
 1. Run `python3 scripts/build-website.py` to regenerate `data.json`
 2. Commit both `data.json` and any changes

--- a/docs/data.json
+++ b/docs/data.json
@@ -111,6 +111,14 @@
         "allowed_tools": "Bash Read Grep Glob"
       },
       {
+        "name": "aipcc-commit-suggest",
+        "description": "Generate AIPCC Commits style commit messages or summarize existing commits",
+        "category": "aipcc",
+        "file_path": "helpers/skills/aipcc-commit-suggest/SKILL.md",
+        "id": "aipcc-commit-suggest",
+        "allowed_tools": ""
+      },
+      {
         "name": "code-review",
         "description": "Perform AI code review on a GitLab MR or local branch. Reviews all commits since the base branch, produces structured JSON feedback with inline comments, and posts results to GitLab (CI) or displays them locally. Use when asked to review code changes, do a code review, or run ai-review.\n",
         "category": "general",
@@ -295,6 +303,14 @@
         "allowed_tools": "Bash"
       },
       {
+        "name": "hello-world-echo",
+        "description": "Hello world plugin implementation",
+        "category": "general",
+        "file_path": "helpers/skills/hello-world-echo/SKILL.md",
+        "id": "hello-world-echo",
+        "allowed_tools": ""
+      },
+      {
         "name": "jira-activity",
         "description": "Summarize Jira ticket activity, including child tickets, to detect stale tickets in the backlog. Use when user asks to review one or more Jira tickets to determine if they are being worked on.",
         "category": "jira management",
@@ -317,6 +333,14 @@
         "file_path": "helpers/skills/jira-autofix-cve-resolve/SKILL.md",
         "id": "jira-autofix-cve-resolve",
         "allowed_tools": "Read Write Bash Skill"
+      },
+      {
+        "name": "jira-sprint-summary",
+        "description": "Generate comprehensive sprint summaries by analyzing JIRA sprint data, including issue breakdown, progress metrics, and team performance insights.",
+        "category": "general",
+        "file_path": "helpers/skills/jira-sprint-summary/SKILL.md",
+        "id": "jira-sprint-summary",
+        "allowed_tools": ""
       },
       {
         "name": "jira-status-summary",
@@ -365,6 +389,22 @@
         "file_path": "helpers/skills/jira-workitem-view/SKILL.md",
         "id": "jira-workitem-view",
         "allowed_tools": "Bash, Skill"
+      },
+      {
+        "name": "konflux-application",
+        "description": "Manage Konflux application",
+        "category": "general",
+        "file_path": "helpers/skills/konflux-application/SKILL.md",
+        "id": "konflux-application",
+        "allowed_tools": ""
+      },
+      {
+        "name": "konflux-component",
+        "description": "Manage Konflux component",
+        "category": "general",
+        "file_path": "helpers/skills/konflux-component/SKILL.md",
+        "id": "konflux-component",
+        "allowed_tools": ""
       },
       {
         "name": "learning-mode",
@@ -487,6 +527,14 @@
         "allowed_tools": "Bash Read Grep"
       },
       {
+        "name": "rpm-examine",
+        "description": "Analyze RPM build.log failures",
+        "category": "general",
+        "file_path": "helpers/skills/rpm-examine/SKILL.md",
+        "id": "rpm-examine",
+        "allowed_tools": ""
+      },
+      {
         "name": "security-alert",
         "description": "Use this skill to filter a pre-fetched set of Hacker News stories down to those that report supply-chain security threats relevant to software developers — including malicious packages on npm or PyPI, compromised developer tooling, and attacks targeting source code repositories or CI/CD infrastructure. Reads stories from stories.json in the workspace, performs semantic analysis (fetching HN threads when the title alone is ambiguous), and writes the stories worth alerting on to findings.json.",
         "category": "aipcc",
@@ -509,6 +557,22 @@
         "file_path": "helpers/skills/torchtalk-analyzer/SKILL.md",
         "id": "torchtalk-analyzer",
         "allowed_tools": "Bash Read Grep Glob"
+      },
+      {
+        "name": "torchtalk-setup",
+        "description": "Install and configure TorchTalk MCP server for PyTorch cross-language analysis",
+        "category": "pytorch",
+        "file_path": "helpers/skills/torchtalk-setup/SKILL.md",
+        "id": "torchtalk-setup",
+        "allowed_tools": ""
+      },
+      {
+        "name": "torchtalk-trace",
+        "description": "Trace a PyTorch function's cross-language binding chain (Python -> C++ -> CUDA)",
+        "category": "pytorch",
+        "file_path": "helpers/skills/torchtalk-trace/SKILL.md",
+        "id": "torchtalk-trace",
+        "allowed_tools": ""
       },
       {
         "name": "triage-bug-readiness",
@@ -589,72 +653,6 @@
         "file_path": "helpers/skills/vllm-slack-summary/SKILL.md",
         "id": "vllm-slack-summary",
         "allowed_tools": ""
-      }
-    ],
-    "commands": [
-      {
-        "name": "aipcc-commit-suggest",
-        "description": "Generate AIPCC Commits style commit messages or summarize existing commits",
-        "category": "aipcc",
-        "file_path": "helpers/commands/aipcc-commit-suggest.md",
-        "argument_hint": "[N]",
-        "synopsis": "/aipcc:commit-suggest       # Analyze staged changes"
-      },
-      {
-        "name": "hello-world-echo",
-        "description": "Hello world plugin implementation",
-        "category": "general",
-        "file_path": "helpers/commands/hello-world-echo.md",
-        "argument_hint": "[name]",
-        "synopsis": "/hello-world:echo [name]"
-      },
-      {
-        "name": "jira-sprint-summary",
-        "description": "Generate comprehensive sprint summaries by analyzing JIRA sprint data, including issue breakdown, progress metrics, and team performance insights.",
-        "category": "general",
-        "file_path": "helpers/commands/jira-sprint-summary.md",
-        "argument_hint": "<sprint-name> [options]",
-        "synopsis": "/jira:sprint-summary <sprint-name> [options]"
-      },
-      {
-        "name": "konflux-application",
-        "description": "Manage Konflux application",
-        "category": "general",
-        "file_path": "helpers/commands/konflux-application.md",
-        "argument_hint": "<subcommand> [args]",
-        "synopsis": "/konflux:application status <application>"
-      },
-      {
-        "name": "konflux-component",
-        "description": "Manage Konflux component",
-        "category": "general",
-        "file_path": "helpers/commands/konflux-component.md",
-        "argument_hint": "<subcommand> [args]",
-        "synopsis": "/konflux:component status <component>"
-      },
-      {
-        "name": "rpm-examine",
-        "description": "Analyze RPM build.log failures",
-        "category": "general",
-        "file_path": "helpers/commands/rpm-examine.md",
-        "argument_hint": "\"[copr-chroot-url] OR [build-log-url] [srpm-url] OR [build.log] [specfile|dist-git] [sources]\"",
-        "synopsis": "/rpm:examine <copr-chroot-url>"
-      },
-      {
-        "name": "torchtalk-setup",
-        "description": "Install and configure TorchTalk MCP server for PyTorch cross-language analysis",
-        "category": "pytorch",
-        "file_path": "helpers/commands/torchtalk-setup.md",
-        "argument_hint": "",
-        "synopsis": "/torchtalk:setup"
-      },
-      {
-        "name": "torchtalk-trace",
-        "description": "Trace a PyTorch function's cross-language binding chain (Python -> C++ -> CUDA)",
-        "category": "pytorch",
-        "file_path": "helpers/commands/torchtalk-trace.md",
-        "argument_hint": "<function-name> [focus]",
-        "synopsis": "/torchtalk:trace <function-name>"
       }
     ],
     "agents": [

--- a/docs/index.html
+++ b/docs/index.html
@@ -350,12 +350,6 @@
             color: white;
         }
 
-        .autocomplete-item-icon.command {
-            background: var(--bg-code);
-            color: var(--success);
-            border: 1px solid var(--border);
-        }
-
         .autocomplete-item-icon.skill {
             background: var(--bg-code);
             color: var(--accent);
@@ -1006,16 +1000,12 @@
             <div class="navbar-brand">
                 <div class="navbar-title">
                     <h1>AI Helpers Marketplace</h1>
-                    <p class="subtitle">Skills, Commands, Agents & Gems</p>
+                    <p class="subtitle">Skills, Agents & Gems</p>
                 </div>
                 <div class="navbar-stats">
                     <div class="stat">
                         <div class="stat-value" id="plugin-count">0</div>
                         <div class="stat-label">Tools</div>
-                    </div>
-                    <div class="stat">
-                        <div class="stat-value" id="command-count">0</div>
-                        <div class="stat-label">Commands</div>
                     </div>
                     <div class="stat">
                         <div class="stat-value" id="skill-count">0</div>
@@ -1044,7 +1034,7 @@
                 type="text"
                 id="search"
                 class="search-input"
-                placeholder="Search skills, commands, agents, and gems..."
+                placeholder="Search skills, agents, and gems..."
                 autocomplete="off"
             >
             <div id="autocomplete" class="autocomplete-dropdown"></div>
@@ -1058,11 +1048,6 @@
                         <input type="checkbox" id="filter-skills" value="skills" checked>
                         <span class="checkbox-custom"></span>
                         <span class="checkbox-label claude-code">Skills</span>
-                    </label>
-                    <label class="filter-checkbox">
-                        <input type="checkbox" id="filter-commands" value="commands" checked>
-                        <span class="checkbox-custom"></span>
-                        <span class="checkbox-label cursor">Commands</span>
                     </label>
                     <label class="filter-checkbox">
                         <input type="checkbox" id="filter-agents" value="agents" checked>
@@ -1088,7 +1073,7 @@
         <div class="plugins-grid" id="plugins-grid"></div>
 
         <div class="no-results" id="no-results">
-            No tools or commands found matching your search.
+            No tools found matching your search.
         </div>
     </div>
 
@@ -1136,13 +1121,11 @@
 
         function getSelectedToolTypes() {
             const skillsChecked = document.getElementById('filter-skills').checked;
-            const commandsChecked = document.getElementById('filter-commands').checked;
             const agentsChecked = document.getElementById('filter-agents').checked;
             const geminiChecked = document.getElementById('filter-gemini').checked;
 
             const selected = [];
             if (skillsChecked) selected.push('skills');
-            if (commandsChecked) selected.push('commands');
             if (agentsChecked) selected.push('agents');
             if (geminiChecked) selected.push('gemini');
 
@@ -1238,19 +1221,7 @@
                         ...tool,
                         tool_type: 'skills',
                         display_name: tool.name,
-                        commands: [], // Skills don't have commands
-                        skills: [tool], // The tool itself is a skill
-                        agents: []
-                    })));
-                }
-
-                if (toolsData.commands) {
-                    allTools.push(...toolsData.commands.map(tool => ({
-                        ...tool,
-                        tool_type: 'commands',
-                        display_name: tool.name,
-                        commands: [tool], // The tool itself is a command
-                        skills: [],
+                        skills: [tool],
                         agents: []
                     })));
                 }
@@ -1260,9 +1231,8 @@
                         ...tool,
                         tool_type: 'agents',
                         display_name: tool.name,
-                        commands: [], // Agents don't have commands
                         skills: [],
-                        agents: [tool] // The tool itself is an agent
+                        agents: [tool]
                     })));
                 }
 
@@ -1271,7 +1241,6 @@
                         ...tool,
                         tool_type: 'gemini',
                         display_name: tool.display_name || tool.name,
-                        commands: [],
                         skills: [],
                         agents: []
                     })));
@@ -1283,8 +1252,6 @@
                 // Update stats
                 const totalTools = allTools.length;
                 document.getElementById('plugin-count').textContent = totalTools;
-                const totalCommands = toolsData.commands ? toolsData.commands.length : 0;
-                document.getElementById('command-count').textContent = totalCommands;
                 const totalSkills = toolsData.skills ? toolsData.skills.length : 0;
                 document.getElementById('skill-count').textContent = totalSkills;
                 const totalAgents = toolsData.agents ? toolsData.agents.length : 0;
@@ -1321,9 +1288,6 @@
                 if (tool.tool_type === 'skills') {
                     toolTypeColor = 'var(--accent)';
                     toolTypeLabel = 'Skill';
-                } else if (tool.tool_type === 'commands') {
-                    toolTypeColor = 'var(--primary)';
-                    toolTypeLabel = 'Command';
                 } else if (tool.tool_type === 'agents') {
                     toolTypeColor = 'var(--secondary)';
                     toolTypeLabel = 'Agent';
@@ -1358,9 +1322,6 @@
             if (tool.tool_type === 'skills') {
                 toolTypeColor = 'var(--accent)';
                 toolTypeLabel = 'Skill';
-            } else if (tool.tool_type === 'commands') {
-                toolTypeColor = 'var(--primary)';
-                toolTypeLabel = 'Command';
             } else if (tool.tool_type === 'agents') {
                 toolTypeColor = 'var(--secondary)';
                 toolTypeLabel = 'Agent';
@@ -1395,10 +1356,6 @@
                         <div style="font-size: 0.875rem; color: var(--text-secondary);">
                             See <a href="https://cursor.com/docs/context/skills" target="_blank" rel="noopener noreferrer" style="color: var(--accent);">Cursor Skills documentation</a>
                         </div>
-                        ` : tool.tool_type === 'commands' ? `
-                        <div style="font-size: 0.875rem; color: var(--text-secondary);">
-                            See <a href="https://cursor.com/docs/context/commands" target="_blank" rel="noopener noreferrer" style="color: var(--accent);">Cursor Commands documentation</a>
-                        </div>
                         ` : `
                         <div style="font-size: 0.875rem; color: var(--text-secondary);">
                             See <a href="https://cursor.com/docs/context/subagents" target="_blank" rel="noopener noreferrer" style="color: var(--accent);">Cursor Sub-agents documentation</a>
@@ -1410,8 +1367,6 @@
                         <div style="font-weight: 600; margin-bottom: 0.5rem;">OpenCode.ai</div>
                         ${tool.tool_type === 'skills' ? `
                         <div style="font-size: 0.875rem; color: var(--text-secondary);">Install as skills in ~/.config/opencode/skills/</div>
-                        ` : tool.tool_type === 'commands' ? `
-                        <div style="font-size: 0.875rem; color: var(--text-secondary);">Install as commands in ~/.config/opencode/commands/</div>
                         ` : tool.tool_type === 'agents' ? `
                         <div style="font-size: 0.875rem; color: var(--text-secondary);">⚠️ Not currently compatible with OpenCode.ai</div>
                         ` : `
@@ -1439,14 +1394,6 @@
                     <div style="margin-top: 1rem; padding: 1rem; background: var(--bg-code); border-radius: 8px; border-left: 3px solid var(--accent);">
                         ${tool.id ? `<div style="font-family: monospace; font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.5rem;">Skill ID: ${tool.id}</div>` : ''}
                         ${tool.allowed_tools ? `<div style="font-size: 0.875rem; color: var(--text-secondary);"><strong>Allowed Tools:</strong> ${tool.allowed_tools}</div>` : ''}
-                        ${tool.file_path ? `<div class="file-link" style="margin-top: 0.5rem;"><a href="https://github.com/opendatahub-io/ai-helpers/blob/main/${tool.file_path}" target="_blank" rel="noopener noreferrer" class="source-link">📄 View Source</a></div>` : ''}
-                    </div>
-                `;
-            } else if (tool.tool_type === 'commands') {
-                content += `
-                    <div style="margin-top: 1rem; padding: 1rem; background: var(--bg-code); border-radius: 8px;">
-                        ${tool.synopsis ? `<div style="font-family: monospace; font-size: 0.85rem; color: var(--success); margin-bottom: 0.5rem;">${tool.synopsis}</div>` : ''}
-                        ${tool.argument_hint ? `<div style="font-size: 0.875rem; color: var(--text-muted); margin-bottom: 0.5rem;"><strong>Arguments:</strong> ${tool.argument_hint}</div>` : ''}
                         ${tool.file_path ? `<div class="file-link" style="margin-top: 0.5rem;"><a href="https://github.com/opendatahub-io/ai-helpers/blob/main/${tool.file_path}" target="_blank" rel="noopener noreferrer" class="source-link">📄 View Source</a></div>` : ''}
                     </div>
                 `;
@@ -1478,7 +1425,6 @@
             // Find matching items
             const results = {
                 tools: [],
-                commands: [],
                 skills: [],
                 agents: []
             };
@@ -1489,18 +1435,6 @@
                     tool.description.toLowerCase().includes(lowerQuery)) {
                     results.tools.push(tool);
                 }
-
-                // Check command matches
-                tool.commands.forEach(cmd => {
-                    if (cmd.name.toLowerCase().includes(lowerQuery) ||
-                        (cmd.description && cmd.description.toLowerCase().includes(lowerQuery)) ||
-                        (cmd.synopsis && cmd.synopsis.toLowerCase().includes(lowerQuery))) {
-                        results.commands.push({
-                            tool: tool,
-                            command: cmd
-                        });
-                    }
-                });
 
                 // Check skill matches
                 const skills = tool.skills || [];
@@ -1538,7 +1472,6 @@
             // Filter tool cards
             const matchedToolIds = new Set([
                 ...results.tools.map(t => `${t.name}-${t.tool_type}`),
-                ...results.commands.map(c => `${c.tool.name}-${c.tool.tool_type}`),
                 ...results.skills.map(s => `${s.tool.name}-${s.tool.tool_type}`),
                 ...results.agents.map(a => `${a.tool.name}-${a.tool.tool_type}`)
             ]);
@@ -1548,7 +1481,7 @@
 
         function updateAutocomplete(results) {
             const autocomplete = document.getElementById('autocomplete');
-            const hasResults = results.tools.length > 0 || results.commands.length > 0 || results.skills.length > 0 || results.agents.length > 0;
+            const hasResults = results.tools.length > 0 || results.skills.length > 0 || results.agents.length > 0;
 
             if (!hasResults) {
                 autocomplete.innerHTML = '<div class="autocomplete-empty">No matches found</div>';
@@ -1567,26 +1500,8 @@
                             <div class="autocomplete-item" onclick="showPluginModal('${tool.name}', '${tool.tool_type}')">
                                 <div class="autocomplete-item-icon plugin">${tool.name.charAt(0).toUpperCase()}</div>
                                 <div class="autocomplete-item-content">
-                                    <div class="autocomplete-item-title">${tool.name} (${tool.tool_type === 'skills' ? 'Skill' : tool.tool_type === 'commands' ? 'Command' : tool.tool_type === 'agents' ? 'Agent' : 'Gemini Gem'})</div>
+                                    <div class="autocomplete-item-title">${tool.name} (${tool.tool_type === 'skills' ? 'Skill' : tool.tool_type === 'agents' ? 'Agent' : 'Gemini Gem'})</div>
                                     <div class="autocomplete-item-subtitle">${tool.description}</div>
-                                </div>
-                            </div>
-                        `).join('')}
-                    </div>
-                `;
-            }
-
-            // Commands section
-            if (results.commands.length > 0) {
-                html += `
-                    <div class="autocomplete-section">
-                        <div class="autocomplete-section-title">Commands</div>
-                        ${results.commands.slice(0, 10).map(item => `
-                            <div class="autocomplete-item" onclick="showPluginModal('${item.tool.name}', '${item.tool.tool_type}')">
-                                <div class="autocomplete-item-icon command">$</div>
-                                <div class="autocomplete-item-content">
-                                    <div class="autocomplete-item-title">${item.command.synopsis || '/' + item.command.name}</div>
-                                    <div class="autocomplete-item-subtitle">${item.command.description || item.command.synopsis || ''}</div>
                                 </div>
                             </div>
                         `).join('')}
@@ -1665,16 +1580,6 @@
 
         // Filter functionality
         document.getElementById('filter-skills').addEventListener('change', () => {
-            applyFilters();
-            const currentQuery = document.getElementById('search').value;
-            if (currentQuery.trim()) {
-                searchAndShowAutocomplete(currentQuery);
-            } else {
-                renderPlugins(filteredTools);
-            }
-        });
-
-        document.getElementById('filter-commands').addEventListener('change', () => {
             applyFilters();
             const currentQuery = document.getElementById('search').value;
             if (currentQuery.trim()) {
@@ -1815,8 +1720,8 @@
                 </p>
 
                 <div style="position: relative; margin-bottom: 1.5rem;">
-                    <div class="code-block" style="padding-right: 5rem;">cd ai-helpers && mkdir -p ~/.cursor/commands ~/.cursor/skills ~/.cursor/agents</div>
-                    <button class="copy-button" onclick="copyToClipboard('cd ai-helpers && mkdir -p ~/.cursor/commands ~/.cursor/skills ~/.cursor/agents', event)" title="Copy to clipboard">
+                    <div class="code-block" style="padding-right: 5rem;">cd ai-helpers && mkdir -p ~/.cursor/skills ~/.cursor/agents</div>
+                    <button class="copy-button" onclick="copyToClipboard('cd ai-helpers && mkdir -p ~/.cursor/skills ~/.cursor/agents', event)" title="Copy to clipboard">
                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M5.75 4.75H10.25V1.75H5.75V4.75ZM5.75 4.75H2.75V14.25H10.25V11.25M5.75 4.75V7.75H13.25V14.25H10.25V11.25M10.25 11.25H13.25V7.75H5.75V4.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
@@ -1825,8 +1730,8 @@
                 </div>
 
                 <div style="position: relative; margin-bottom: 1.5rem;">
-                    <div class="code-block" style="padding-right: 5rem;">ln -sf $(pwd)/helpers/commands/* ~/.cursor/commands/ && ln -sf $(pwd)/helpers/skills/* ~/.cursor/skills/ && ln -sf $(pwd)/helpers/agents/* ~/.cursor/agents/</div>
-                    <button class="copy-button" onclick="copyToClipboard('ln -sf $(pwd)/helpers/commands/* ~/.cursor/commands/ && ln -sf $(pwd)/helpers/skills/* ~/.cursor/skills/ && ln -sf $(pwd)/helpers/agents/* ~/.cursor/agents/', event)" title="Copy to clipboard">
+                    <div class="code-block" style="padding-right: 5rem;">ln -sf $(pwd)/helpers/skills/* ~/.cursor/skills/ && ln -sf $(pwd)/helpers/agents/* ~/.cursor/agents/</div>
+                    <button class="copy-button" onclick="copyToClipboard('ln -sf $(pwd)/helpers/skills/* ~/.cursor/skills/ && ln -sf $(pwd)/helpers/agents/* ~/.cursor/agents/', event)" title="Copy to clipboard">
                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M5.75 4.75H10.25V1.75H5.75V4.75ZM5.75 4.75H2.75V14.25H10.25V11.25M5.75 4.75V7.75H13.25V14.25H10.25V11.25M10.25 11.25H13.25V7.75H5.75V4.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
@@ -1877,8 +1782,8 @@
                 </p>
 
                 <div style="position: relative; margin-bottom: 1.5rem;">
-                    <div class="code-block" style="padding-right: 5rem;">mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands</div>
-                    <button class="copy-button" onclick="copyToClipboard('mkdir -p ~/.config/opencode/skills ~/.config/opencode/commands', event)" title="Copy to clipboard">
+                    <div class="code-block" style="padding-right: 5rem;">mkdir -p ~/.config/opencode/skills</div>
+                    <button class="copy-button" onclick="copyToClipboard('mkdir -p ~/.config/opencode/skills', event)" title="Copy to clipboard">
                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M5.75 4.75H10.25V1.75H5.75V4.75ZM5.75 4.75H2.75V14.25H10.25V11.25M5.75 4.75V7.75H13.25V14.25H10.25V11.25M10.25 11.25H13.25V7.75H5.75V4.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
@@ -1887,8 +1792,8 @@
                 </div>
 
                 <div style="position: relative; margin-bottom: 1.5rem;">
-                    <div class="code-block" style="padding-right: 5rem;">ln -sf $(pwd)/helpers/skills/* ~/.config/opencode/skills/ && ln -sf $(pwd)/helpers/commands/* ~/.config/opencode/commands/</div>
-                    <button class="copy-button" onclick="copyToClipboard('ln -sf $(pwd)/helpers/skills/* ~/.config/opencode/skills/ && ln -sf $(pwd)/helpers/commands/* ~/.config/opencode/commands/', event)" title="Copy to clipboard">
+                    <div class="code-block" style="padding-right: 5rem;">ln -sf $(pwd)/helpers/skills/* ~/.config/opencode/skills/</div>
+                    <button class="copy-button" onclick="copyToClipboard('ln -sf $(pwd)/helpers/skills/* ~/.config/opencode/skills/', event)" title="Copy to clipboard">
                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M5.75 4.75H10.25V1.75H5.75V4.75ZM5.75 4.75H2.75V14.25H10.25V11.25M5.75 4.75V7.75H13.25V14.25H10.25V11.25M10.25 11.25H13.25V7.75H5.75V4.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                         </svg>
@@ -1939,7 +1844,7 @@
                         const toolType = parts[parts.length - 1];
                         const toolName = parts.slice(0, -1).join('-');
 
-                        if (toolType === 'skills' || toolType === 'commands' || toolType === 'agents' || toolType === 'gemini') {
+                        if (toolType === 'skills' || toolType === 'agents' || toolType === 'gemini') {
                             const tool = allTools.find(t => t.name === toolName && t.tool_type === toolType);
                             if (tool) {
                                 showPluginModal(toolName, toolType);

--- a/helpers/skills/aipcc-commit-suggest/SKILL.md
+++ b/helpers/skills/aipcc-commit-suggest/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: aipcc-commit-suggest
 description: Generate AIPCC Commits style commit messages or summarize existing commits
 argument-hint: [N]
 ---

--- a/helpers/skills/hello-world-echo/SKILL.md
+++ b/helpers/skills/hello-world-echo/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: hello-world-echo
 description: Hello world plugin implementation
 argument-hint: [name]
 ---

--- a/helpers/skills/jira-sprint-summary/SKILL.md
+++ b/helpers/skills/jira-sprint-summary/SKILL.md
@@ -1,6 +1,7 @@
 ---
-argument-hint: <sprint-name> [options]
+name: jira-sprint-summary
 description: Generate comprehensive sprint summaries by analyzing JIRA sprint data, including issue breakdown, progress metrics, and team performance insights.
+argument-hint: <sprint-name> [options]
 ---
 
 ## Name

--- a/helpers/skills/konflux-application/SKILL.md
+++ b/helpers/skills/konflux-application/SKILL.md
@@ -1,6 +1,7 @@
 ---
-argument-hint: <subcommand> [args]
+name: konflux-application
 description: Manage Konflux application
+argument-hint: <subcommand> [args]
 ---
 
 ## Name

--- a/helpers/skills/konflux-component/SKILL.md
+++ b/helpers/skills/konflux-component/SKILL.md
@@ -1,6 +1,7 @@
 ---
-argument-hint: <subcommand> [args]
+name: konflux-component
 description: Manage Konflux component
+argument-hint: <subcommand> [args]
 ---
 
 ## Name

--- a/helpers/skills/rpm-examine/SKILL.md
+++ b/helpers/skills/rpm-examine/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: rpm-examine
 description: Analyze RPM build.log failures
 argument-hint: "[copr-chroot-url] OR [build-log-url] [srpm-url] OR [build.log] [specfile|dist-git] [sources]"
 ---

--- a/helpers/skills/torchtalk-setup/SKILL.md
+++ b/helpers/skills/torchtalk-setup/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: torchtalk-setup
 description: Install and configure TorchTalk MCP server for PyTorch cross-language analysis
 ---
 

--- a/helpers/skills/torchtalk-trace/SKILL.md
+++ b/helpers/skills/torchtalk-trace/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: torchtalk-trace
 description: Trace a PyTorch function's cross-language binding chain (Python -> C++ -> CUDA)
 argument-hint: <function-name> [focus]
 ---

--- a/scripts/build-website.py
+++ b/scripts/build-website.py
@@ -51,16 +51,6 @@ def get_filesystem_tools(helpers_dir: Path) -> Dict[str, str]:
             if item.is_dir() and not item.name.startswith("_"):
                 filesystem_tools[item.name] = "skill"
 
-    # Commands - .md files in helpers/commands/
-    commands_dir = helpers_dir / "commands"
-    if commands_dir.exists() and commands_dir.is_dir():
-        for item in commands_dir.iterdir():
-            if item.is_file() and item.suffix == ".md":
-                # Skip README.md files (case-insensitive)
-                if item.name.lower() == "readme.md":
-                    continue
-                filesystem_tools[item.stem] = "command"
-
     # Agents - .md files in helpers/agents/
     agents_dir = helpers_dir / "agents"
     if agents_dir.exists() and agents_dir.is_dir():
@@ -105,8 +95,6 @@ def get_tool_file_path(tool: Dict, base_path: Path) -> str:
         else:
             print(f"Warning: Skill file not found: {skill_file}")
             return f"helpers/skills/{tool_name}/SKILL.md"
-    elif tool_type == "command":
-        return f"helpers/commands/{tool_name}.md"
     elif tool_type == "agent":
         return f"helpers/agents/{tool_name}.md"
     elif tool_type == "gem":
@@ -159,49 +147,6 @@ def get_tool_metadata(tool: Dict, category: str, base_path: Path) -> Dict:
             metadata["id"] = tool["name"]
         if "allowed_tools" not in metadata:
             metadata["allowed_tools"] = ""
-
-    elif tool_type == "command":
-        # Read command metadata from frontmatter
-        cmd_file = base_path / "helpers" / "commands" / f"{tool['name']}.md"
-        if cmd_file.exists():
-            try:
-                content = cmd_file.read_text()
-                frontmatter = {}
-
-                # Parse frontmatter - simple key: value parser
-                if content.startswith("---\n"):
-                    end_marker = content.find("\n---\n", 4)
-                    if end_marker != -1:
-                        frontmatter_content = content[4:end_marker]
-                        for line in frontmatter_content.strip().split("\n"):
-                            if ":" in line:
-                                key, value = line.split(":", 1)
-                                frontmatter[key.strip()] = value.strip()
-
-                # Extract synopsis
-                import re
-
-                match = re.search(r"## Synopsis\s*```[^\n]*\n([^\n]+)", content, re.MULTILINE)
-
-                # Only add synopsis to metadata if we found a non-empty match
-                metadata_updates = {
-                    "description": frontmatter.get("description", ""),
-                    "argument_hint": frontmatter.get("argument-hint", ""),
-                }
-                if match:
-                    synopsis = match.group(1).strip()
-                    if synopsis:  # Only add if non-empty
-                        metadata_updates["synopsis"] = synopsis
-
-                metadata.update(metadata_updates)
-            except Exception as e:
-                print(f"Warning: Could not read command metadata from {cmd_file}: {e}")
-
-        # Add default fields for commands
-        if "synopsis" not in metadata:
-            metadata["synopsis"] = f"/{tool['name']}"
-        if "argument_hint" not in metadata:
-            metadata["argument_hint"] = ""
 
     elif tool_type == "agent":
         # Read agent metadata from frontmatter
@@ -330,7 +275,7 @@ def build_website_data():
         "name": "odh-ai-helpers",
         "owner": "ODH",
         "categories": categories,
-        "tools": {"gemini": [], "skills": [], "commands": [], "agents": []},
+        "tools": {"gemini": [], "skills": [], "agents": []},
     }
 
     # Process General tools first (uncategorized tools)
@@ -344,8 +289,6 @@ def build_website_data():
 
                 if tool_type == "skill":
                     website_data["tools"]["skills"].append(tool_metadata)
-                elif tool_type == "command":
-                    website_data["tools"]["commands"].append(tool_metadata)
                 elif tool_type == "agent":
                     website_data["tools"]["agents"].append(tool_metadata)
                 elif tool_type == "gem":
@@ -378,8 +321,6 @@ def build_website_data():
 
             if tool_type == "skill":
                 website_data["tools"]["skills"].append(tool_metadata)
-            elif tool_type == "command":
-                website_data["tools"]["commands"].append(tool_metadata)
             elif tool_type == "agent":
                 website_data["tools"]["agents"].append(tool_metadata)
             elif tool_type == "gem":
@@ -387,7 +328,6 @@ def build_website_data():
 
     # Sort all tool arrays alphabetically by name to ensure consistent ordering
     website_data["tools"]["skills"].sort(key=lambda x: x["name"])
-    website_data["tools"]["commands"].sort(key=lambda x: x["name"])
     website_data["tools"]["agents"].sort(key=lambda x: x["name"])
     website_data["tools"]["gemini"].sort(key=lambda x: x["name"])
 
@@ -408,13 +348,11 @@ if __name__ == "__main__":
 
     # Calculate statistics for new tool structure
     skills_tools = data["tools"]["skills"]
-    commands_tools = data["tools"]["commands"]
     agents_tools = data["tools"]["agents"]
     gemini_tools = data["tools"]["gemini"]
-    all_tools = skills_tools + commands_tools + agents_tools + gemini_tools
+    all_tools = skills_tools + agents_tools + gemini_tools
 
     print(f"Total Skills: {len(skills_tools)}")
-    print(f"Total Commands: {len(commands_tools)}")
     print(f"Total Agents: {len(agents_tools)}")
     print(f"Total Gemini Gems: {len(gemini_tools)}")
     print(f"Total tools: {len(all_tools)}")

--- a/scripts/update_claude_settings.py
+++ b/scripts/update_claude_settings.py
@@ -90,24 +90,6 @@ def get_filesystem_tools(helpers_dir: Path) -> Dict[str, str]:
                     )
                 filesystem_tools[tool_name] = "skill"
 
-    # Commands - .md files in helpers/commands/
-    commands_dir = helpers_dir / "commands"
-    if commands_dir.exists() and commands_dir.is_dir():
-        for item in commands_dir.iterdir():
-            if item.is_file() and item.suffix == ".md":
-                # Skip README.md files (case-insensitive)
-                if item.name.lower() == "readme.md":
-                    continue
-                tool_name = item.stem
-                if tool_name in filesystem_tools:
-                    print(
-                        f"Warning: Duplicate tool name '{tool_name}' found"
-                        f" - command ({item}) conflicts with"
-                        f" {filesystem_tools[tool_name]}",
-                        file=sys.stderr,
-                    )
-                filesystem_tools[tool_name] = "command"
-
     # Agents - .md files in helpers/agents/
     agents_dir = helpers_dir / "agents"
     if agents_dir.exists() and agents_dir.is_dir():
@@ -171,8 +153,6 @@ def get_tool_source_path(tool: Dict) -> str:
 
     if tool_type == "skill":
         return f"./helpers/skills/{tool_name}"
-    elif tool_type == "command":
-        return f"./helpers/commands/{tool_name}.md"
     elif tool_type == "agent":
         return f"./helpers/agents/{tool_name}.md"
     elif tool_type == "gem":

--- a/scripts/validate_tools.py
+++ b/scripts/validate_tools.py
@@ -30,7 +30,7 @@ except ImportError:
     sys.exit(1)
 
 
-VALID_TOOL_TYPES = {"skill", "command", "agent", "gem"}
+VALID_TOOL_TYPES = {"skill", "agent", "gem"}
 
 
 def title_to_slug(title: str) -> str:
@@ -62,23 +62,6 @@ def get_filesystem_tools_with_duplicates_check(
                     tool_locations[tool_name] = []
                 tool_locations[tool_name].append(("skill", str(item)))
                 filesystem_tools[tool_name] = "skill"
-
-    # Commands - .md files in helpers/commands/
-    commands_dir = helpers_dir / "commands"
-    if commands_dir.exists() and commands_dir.is_dir():
-        for item in commands_dir.iterdir():
-            if item.is_file() and item.suffix == ".md":
-                # Skip README.md files (case-insensitive)
-                if item.name.lower() == "readme.md":
-                    continue
-                tool_name = item.stem
-                if tool_name not in tool_locations:
-                    tool_locations[tool_name] = []
-                tool_locations[tool_name].append(("command", str(item)))
-                if tool_name in filesystem_tools:
-                    # Already exists with different type
-                    continue
-                filesystem_tools[tool_name] = "command"
 
     # Agents - .md files in helpers/agents/
     agents_dir = helpers_dir / "agents"


### PR DESCRIPTION
Claude Code has merged commands and skills into a single concept — both create slash commands and work identically. This removes the separate "commands" tool type, converting all 8 commands into skills and simplifying the taxonomy from 4 tool types to 3 (skills, agents, gems).

- Convert 8 commands to helpers/skills/<name>/SKILL.md
- Delete helpers/commands/ directory
- Remove command handling from build scripts
- Update website, docs, and config files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several new skills to the site catalog and documentation, with updated metadata for each.
  * The website now focuses on skills, agents, and gems, with refreshed filtering, search, and navigation.

* **Bug Fixes**
  * Improved guidance so non-executable text is not incorrectly flagged for security issues.
  * Removed outdated command-related setup and validation steps from docs and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->