### PR TITLE
feat: add pipeline-skills external plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,14 @@
       }
     },
     {
+      "name": "pipeline-skills",
+      "description": "Pipeline failure analysis \u2014 error grouping and root cause analysis",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/opendatahub-io/pipeline-skills.git"
+      }
+    },
+    {
       "name": "odh-ai-helpers",
       "source": "./helpers",
       "description": "AI automation tools, plugins, and assistants for enhanced productivity",

--- a/claude-external-plugin-sources.json
+++ b/claude-external-plugin-sources.json
@@ -16,6 +16,14 @@
         "source": "url",
         "url": "https://github.com/opendatahub-io/autofix-skills.git"
       }
+    },
+    {
+      "name": "pipeline-skills",
+      "description": "Pipeline failure analysis — error grouping and root cause analysis",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/opendatahub-io/pipeline-skills.git"
+      }
     }
   ]
 }

--- a/images/claude/claude-settings.json
+++ b/images/claude/claude-settings.json
@@ -10,6 +10,7 @@
   "enabledPlugins": {
     "odh-ai-helpers@odh-ai-helpers": true,
     "odh-ai-helpers@fips-compliance-checker": true,
-    "odh-ai-helpers@autofix-skills": true
+    "odh-ai-helpers@autofix-skills": true,
+    "odh-ai-helpers@pipeline-skills": true
   }
 }


### PR DESCRIPTION
## Summary

Register [opendatahub-io/pipeline-skills](https://github.com/opendatahub-io/pipeline-skills) as an external plugin. This adds two skills for AIPCC pipeline failure analysis — error grouping and root cause analysis — under a new "GitLab Pipeline Analysis" category.

## Type of Contribution

- [x] 🎯 New skill
- [x] 📋 New category addition

## Changes Made

- Added `pipeline-skills` entry to `claude-external-plugin-sources.json`
- Added `GitLab Pipeline Analysis` category to `categories.yaml` with `pipeline-grouping` and `pipeline-rca`
- Ran `make update` to regenerate `claude-settings.json`, `marketplace.json`, and `docs/data.json`

### Skill
- **Skill name**: `pipeline-grouping`, `pipeline-rca`
- **Primary use case**: Automated analysis of failed GitLab CI/CD pipelines — groups failures by shared root cause, then performs root cause analysis with structured findings
- **Dependencies required**: None (skills are self-contained in the external plugin repo)

## Testing and Validation

### Required Checks
- [x] 🔄 Ran `make update` and committed any generated changes
- [ ] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing
- [x] Claude Code: Tested end-to-end via [pipeline-failure-analyzer MR !21](https://gitlab.com/redhat/rhel-ai/core/tools/pipeline-failure-analyzer/-/merge_requests/21) — skills successfully ran grouping and RCA against a real failed pipeline

## Categorization
- [x] Tool is properly categorized in `categories.yaml` (or uses default "General" category)

## Ethical Guidelines Compliance
- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation
- [x] Updated relevant README files if needed
- [x] Added appropriate examples and usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements
- External plugin repo: https://github.com/opendatahub-io/pipeline-skills
- No additional dependencies — the plugin is cloned at image build time by `fetch_external_plugins.py`

## Additional Notes

The skills are consumed by [pipeline-failure-analyzer](https://github.com/opendatahub-io/pipeline-failure-analyzer) via the agentic-ci `run_skill()` Python API. The integration was validated in a CI pipeline run against a real failed rhai/pipeline build with multiple error groups.