### PR TITLE
feat: add AIPCC release feature/epic generator skill

### DIFF
--- a/categories.yaml
+++ b/categories.yaml
@@ -3,6 +3,7 @@ AIPCC:
   - commit-message-assistant
   - aipcc-adr-assistant
   - jira-aipcc-create
+  - jira-aipcc-release-feature-epic-generator
   - jira-status-summary
   - security-alert
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -330,6 +330,14 @@
         "allowed_tools": "Bash, AskUserQuestion"
       },
       {
+        "name": "jira-aipcc-release-feature-epic-generator",
+        "description": "Generate JIRA features and epics for an AIPCC release from the accelerator\nvariant planning spreadsheet. Use when creating release work items, generating\nfeature/epic lists for a new release version, or preparing JIRA templates.\nTriggers: \"generate features for release\", \"create release features\",\n\"release feature list\", \"JIRA template for release\".\n",
+        "category": "aipcc",
+        "file_path": "helpers/skills/jira-aipcc-release-feature-epic-generator/SKILL.md",
+        "id": "jira-aipcc-release-feature-epic-generator",
+        "allowed_tools": "Bash, AskUserQuestion, Read, Write"
+      },
+      {
         "name": "jira-autofix-cve-resolve",
         "description": "Use this skill to orchestrate CVE remediation for a Jira Vulnerability ticket. Resolves affected repositories via component-repository-mappings.json, then for each repo and branch: scans, fixes, verifies, and creates PRs. Handles upstream-to-downstream ordering, fork fallback, existing PR detection, VEX justifications, and multi-branch coverage. Writes final verdict to autofix-output/.autofix-verdict.json.",
         "category": "cve remediation",

--- a/helpers/skills/jira-aipcc-release-feature-epic-generator/SKILL.md
+++ b/helpers/skills/jira-aipcc-release-feature-epic-generator/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: jira-aipcc-release-feature-epic-generator
+description: |
+  Generate JIRA features and epics for an AIPCC release from the accelerator
+  variant planning spreadsheet. Use when creating release work items, generating
+  feature/epic lists for a new release version, or preparing JIRA templates.
+  Triggers: "generate features for release", "create release features",
+  "release feature list", "JIRA template for release".
+allowed-tools: Bash, AskUserQuestion, Read, Write
+argument-hint: "<release-version>"
+metadata:
+  author: AIPCC Development Platform
+  tags: [jira, release, aipcc, planning]
+---
+
+# Generate Release Features
+
+Create a complete set of JIRA Features, Epics, Stories, and Tasks for an AIPCC release by reading version data from the accelerator variant planning spreadsheet and applying it to the variant configuration template.
+
+**Paths:** All asset paths in this skill resolve from the skill base directory shown in the skill loading output.
+
+## Prerequisites
+
+Verify before starting:
+
+- `gws` CLI available: `which gws`
+- Google Sheets access authenticated (the spreadsheet requires auth)
+- `acli` CLI available and authenticated: `acli jira auth status`
+
+## Input
+
+**Release version:** `$ARGUMENTS` should contain the release version (e.g., `3.5-EA2`, `3.6-EA1`).
+
+If no version is provided, ask the user for the target release version.
+
+**Spreadsheet URL:** Always ask the user for the Google Spreadsheet URL. The URL may change between releases. Extract the spreadsheet ID from the URL path segment between `/d/` and the next `/`.
+
+## Workflow
+
+### Step 1: Setup
+
+1. Sanitize the version for use as a directory name (remove hyphens: `3.5-EA2` → `3.5EA2`)
+2. Create the output directory: `ep-working-docs/<sanitized-version>/`
+3. Load the variant configuration from `<skill-base>/assets/variant-config.yaml`
+4. Extract the spreadsheet ID from the user-provided URL
+
+### Step 2: Discover Sheets
+
+Read the spreadsheet metadata to list all sheet names:
+
+```bash
+gws sheets spreadsheets get --params '{"spreadsheetId": "<ID>"}' 2>/dev/null
+```
+
+Parse the JSON response to extract sheet titles and IDs. Filter out non-accelerator sheets:
+- Skip sheets named "Retired*", "Major related releases", "Additional info", or similar metadata sheets
+- Keep sheets that match the `sheet` field in any `accelerator_sheets` entry from the variant config
+
+If a sheet in the spreadsheet doesn't match any config entry, note it as unrecognized and report it at the end.
+
+### Step 3: Read All Sheets and Identify Version Tracks
+
+For each accelerator sheet, read ALL rows (up to 50 rows) to capture all version track sections:
+
+```bash
+gws sheets spreadsheets values get --params '{"spreadsheetId": "<ID>", "range": "'<sheet-name>'!A1:Z50"}' 2>/dev/null
+```
+
+Parse the JSON `values` array. Each row is an array of cell values.
+
+**Identify the release header row:** Row index 1 (0-indexed) contains `"Release:"` in column 0, followed by release version names. Find the column index of the target release version. Match flexibly — the spreadsheet may use variations:
+- `"RHAI 3.5 EA2"` or `"RHAI 3.5-EA2"` or `"RHAI 3.5. EA2"`
+- Strip whitespace and normalize when comparing
+
+**Identify version track sections:** Scan rows looking for track headers. A track header row has a non-empty value in column A that matches the `track_pattern` from the variant config for this sheet. Examples:
+- On the CUDA sheet: `"CUDA 12.9"`, `"CUDA 13.0"`, `"CUDA 13.2"`
+- On the ROCm sheet: `"ROCm 6.4"`, `"ROCm 7.1"`, `"ROCm 7.13"`, `"ROCm 7.2"`
+
+Each track section extends from its header row until the next blank row or the next track header.
+
+**Important:** Check for special markers that indicate a track is not for general release:
+- `"INTERNAL ONLY"` in any cell — skip this track
+- `"No Future Releases"` in the target column — mark as discontinued
+
+### Step 4: Filter Active Tracks
+
+For each version track identified in Step 3:
+
+1. Check if the track has data in the target release column (column index found in the release header)
+2. A track is **active** if its header row has a non-empty value in the target column
+3. A track is **discontinued** if the target column contains text like "No Future Releases" or is explicitly marked as ended
+4. A track is **not applicable** if its data doesn't extend to the target column (row is shorter)
+
+Only active tracks become Features. Record the reason for excluding each inactive track.
+
+### Step 5: Extract Version Data
+
+For each active track, scan its rows and extract version data from the target release column:
+
+| Data Point | How to Find |
+|------------|-------------|
+| Accelerator version | Track header row, target column (e.g., "CUDA 12.9", "ROCm 7.2.x") |
+| Python | Row where column A contains "python" (case-insensitive) |
+| Torch | Row where any cell in the row contains "torch" |
+| vLLM | Row where any cell in the row contains "vllm" |
+| Extra versions | Match `extra_version_rows` patterns from variant config |
+
+**Handling version values:**
+- If the cell contains `(?)` or `?`, keep the value but mark it as tentative: `"2.11 (?)"` → `"2.11 (?)"`
+- If the row exists but the target column cell is empty or missing, record as `"TBD"`
+- If the entire row doesn't exist for this track, record as `"TBD"`
+- Strip the package name prefix: `"torch 2.10"` → `"2.10"`, `"vllm 0.19.1"` → `"0.19.1"`
+- Preserve slash alternatives: `"torch 2.10/2.11(?)"` → `"2.10/2.11 (?)"`
+
+### Step 6: Map Tracks to Variants
+
+For each active track, construct the variant name:
+
+1. Look up the sheet's config entry in `accelerator_sheets`
+2. If `variant_name_override` is set, use it as the base name (e.g., `"gaudi"`, `"cpu"`, `"tpu"`)
+3. Otherwise, derive the name from the track header:
+   - Extract the version number from the track name (e.g., `"CUDA 12.9"` → `"12.9"`, `"ROCm 7.2"` → `"7.2"`)
+   - Combine: `{accelerator}{version}` (e.g., `"cuda12.9"`, `"rocm7.2"`)
+4. Append `variant_suffix` (always `"-ubi9"` currently): `"cuda12.9-ubi9"`, `"rocm7.2-ubi9"`
+
+**Select the epic template:**
+- If the sheet config has a simple `epic_template` field, use that template for all tracks
+- If it has `epic_template_rules`, evaluate each rule's `match` against the track's version number. Use the first matching rule's template. Fall back to `default` if no rule matches.
+
+**Handle new/unknown variants:**
+If a track doesn't match any expected pattern, flag it as **(NEW)** in the output and use the closest matching epic template. Note it in the version summary for the user to review.
+
+### Step 7: Generate Outputs
+
+Produce three files in the output directory:
+
+#### 7a. `versions.md` — Version Summary
+
+Structure:
+```markdown
+# RHAI <version> — Accelerator Version Matrix
+
+Extracted from [spreadsheet](URL) on <date>.
+
+## Version Matrix
+| Variant | Python | Torch | vLLM | Accelerator-Specific Version |
+...
+
+## Additional Packages
+(If any variant has extra packages beyond python/torch/vllm)
+
+## Variant Selection Rationale
+| Sheet | Tracks in sheet | Included | Excluded (with reason) |
+...
+
+## Notes
+- List any tentative values, missing data, discontinued tracks, new variants
+```
+
+#### 7b. `<version>-jira-template.yaml` — JIRA Template
+
+Structure:
+```yaml
+release:
+  version: "<version>"
+  products: [from jira_defaults]
+  project: <from jira_defaults>
+  components: [from jira_defaults]
+
+variants:
+  - name: <variant-name>
+    labels: [from squad config]
+    versions:
+      python: "<value>"
+      torch: "<value>"
+      vllm: "<value>"
+      # ... additional per-variant
+    template:
+      - type: Feature
+        summary: "<variant> for <version>"
+        description: "..."
+        assignee: "<from squad config>"
+        watchers: [from squad config]
+        children:
+          - type: Epic
+            summary: "<resolved from epic template>"
+            description: "..."
+          # ... more epics
+
+squads:
+  # Cross-cutting squads from variant config, with {version} resolved
+```
+
+**Resolving placeholders in epic templates:**
+- `{variant}` → variant name (e.g., `"cuda12.9-ubi9"`)
+- `{version}` → release version (e.g., `"3.5-EA2"`)
+- `{torch}` → torch version from spreadsheet (e.g., `"2.10 (?)"`)
+- `{vllm}` → vLLM version from spreadsheet
+- `{accel_version}` → accelerator-specific version (e.g., `"Gaudi 1.24"`)
+- `{accelerator}` → accelerator display name (e.g., `"CUDA"`, `"ROCm 7.2"`)
+
+If a placeholder value is `"TBD"`, keep it as-is in the summary (e.g., `"Update torch to TBD"`). Add a description noting the value is not yet in the spreadsheet.
+
+#### 7c. `features-epics.md` — Human-Readable Listing
+
+Structure:
+```markdown
+# RHAI <version> — Features & Epics
+
+Generated from ... on <date>.
+
+(Explanation of (?) and TBD markers)
+
+---
+
+## 1. <variant-name>
+
+**Squad:** <name> | **Lead:** <lead> (`<assignee>`)
+(**Watchers:** <list>, if any)
+
+| # | Type | Summary | Status |
+|---|------|---------|--------|
+| 1 | Feature | <variant> for <version> | |
+| 1.1 | Epic | <epic summary> | <notes if tentative/TBD> |
+...
+
+---
+(repeat for each variant, numbered sequentially)
+
+## N. Base Images Squad
+## N+1. Delivery Squad
+
+---
+
+## Summary
+| | Features | Epics | Stories | Tasks | Total |
+...
+
+### Changes from base template
+(List any new variants, removed variants, or renamed variants vs the config)
+```
+
+**Numbering:** Variants are numbered sequentially starting at 1. Cross-cutting squads continue the sequence. Within each variant, children are numbered hierarchically (1.1, 1.2, 7.2.1, etc.).
+
+### Step 8: Report
+
+After generating all files, report to the user:
+
+1. Files created (with paths)
+2. Number of Features, Epics, Stories, Tasks generated
+3. Any variants flagged as NEW (not in config)
+4. Any tentative or missing version data that needs squad lead confirmation
+5. Any discontinued or excluded tracks
+
+## JIRA Ticket Creation
+
+After generating the output files, the user may ask to create the actual JIRA tickets. This phase uses the JIRA creation config at `<skill-base>/assets/jira-creation-config.yaml`.
+
+### Required Prompts
+
+Before creating any tickets, **always** perform these steps:
+
+1. **Read the release schedule spreadsheet** — The URL is in `jira-creation-config.yaml` under `schedule_spreadsheet`. Extract the spreadsheet ID and read all rows. Find the section matching the target release (e.g., "RH AI 3.5 EA2" as a row header). Extract key milestone dates from that section. Dates in the spreadsheet may lack a year — infer the year from context (current year or the release timeline). Present a table of key milestones to the user.
+
+2. **Resolve due dates from milestones** — Use the milestone names in `jira-creation-config.yaml` to look up dates:
+   - `due_dates.feature_milestone` → Feature due date (default: "AIPCC Code Freeze")
+   - `due_dates.epic_milestone` → default Epic due date (default: end date of "AIPCC Base Image Development" range)
+   - `epic_due_date_overrides` → per-epic overrides where specific epics use a different milestone. Match epic summaries against the override keys (keys may contain `{version}` placeholders). Apply the override milestone date instead of the default.
+
+   Present the resolved dates to the user for confirmation before proceeding.
+
+3. **Review the JIRA creation config** — Confirm or update: component, label, team, fix version, default assignee, parent issue. Show current values and ask if any need changing.
+
+### Creation Workflow
+
+Process **one variant at a time**. For each variant:
+
+1. Present the Feature and its child Epics to the user for confirmation
+2. Wait for user approval before creating
+3. Create the Feature issue first (captures the returned issue key)
+4. Create each child Epic with `parent` set to the Feature key
+5. Create any child Stories/Tasks with `parent` set to their Epic key
+6. Report the created issue keys
+
+### Issue JSON Template
+
+Use `acli jira workitem create --from-json <file>` with this structure:
+
+```json
+{
+  "projectKey": "<project>",
+  "type": "<Feature|Epic|Story|Task>",
+  "summary": "<from release template>",
+  "description": {
+    "version": 1,
+    "type": "doc",
+    "content": [
+      {
+        "type": "paragraph",
+        "content": [
+          {"type": "text", "text": "<description text>"}
+        ]
+      }
+    ]
+  },
+  "additionalAttributes": {
+    "components": [{"name": "<component>"}],
+    "labels": ["<label>"],
+    "duedate": "<YYYY-MM-DD>",
+    "fixVersions": [{"name": "<fix_version>"}],
+    "customfield_10855": [{"name": "<target_version>"}],
+    "parent": {"key": "<parent-key>"}
+  }
+}
+```
+
+**Field mapping by issue type:**
+
+| Field | Feature | Epic | Story/Task |
+|-------|---------|------|------------|
+| `duedate` | From `feature_milestone` | From `epic_milestone` (or `epic_due_date_overrides` if epic summary matches) | Inherit parent Epic's due date |
+| `parent` | From config (or omit) | Feature key | Epic key |
+| `labels` | From JIRA creation config | From JIRA creation config | From JIRA creation config |
+| `customfield_10855` | Target Version from config | Target Version from config | Target Version from config |
+
+### Team Field
+
+The Team field (`customfield_10001`) may not be settable via API due to Jira screen restrictions. Attempt to set it via `additionalAttributes`; if creation fails, retry without it and inform the user to set it manually on the board.
+
+## Output Reference
+
+Example output from a successful run for RHAI 3.5 EA2 is available at:
+- `ep-working-docs/3.5EA2/versions.md`
+- `ep-working-docs/3.5EA2/3.5-EA2-jira-template.yaml`
+- `ep-working-docs/3.5EA2/features-epics.md`
+
+Use these as reference for output format and content expectations.

--- a/helpers/skills/jira-aipcc-release-feature-epic-generator/SKILL.md
+++ b/helpers/skills/jira-aipcc-release-feature-epic-generator/SKILL.md
@@ -33,13 +33,13 @@ Verify before starting:
 
 If no version is provided, ask the user for the target release version.
 
-**Spreadsheet URL:** Always ask the user for the Google Spreadsheet URL. The URL may change between releases. Extract the spreadsheet ID from the URL path segment between `/d/` and the next `/`.
+**Spreadsheet URL:** Always ask the user for the Google Spreadsheet URL. The URL may change between releases. Extract the spreadsheet ID (the 44-character alphanumeric token) from the URL — it appears after `/d/` and before the next `/` or query parameter (e.g., `?usp=sharing`). Handle URL variants like `/spreadsheets/u/0/d/<ID>/`.
 
 ## Workflow
 
 ### Step 1: Setup
 
-1. Sanitize the version for use as a directory name (remove hyphens: `3.5-EA2` → `3.5EA2`)
+1. Sanitize the version for use as a directory name: strip all characters except alphanumerics, dots, and underscores (e.g., `3.5-EA2` → `3.5EA2`). Reject the input if the result is empty or starts with `.`.
 2. Create the output directory: `ep-working-docs/<sanitized-version>/`
 3. Load the variant configuration from `<skill-base>/assets/variant-config.yaml`
 4. Extract the spreadsheet ID from the user-provided URL
@@ -49,7 +49,7 @@ If no version is provided, ask the user for the target release version.
 Read the spreadsheet metadata to list all sheet names:
 
 ```bash
-gws sheets spreadsheets get --params '{"spreadsheetId": "<ID>"}' 2>/dev/null
+gws sheets spreadsheets get --params '{"spreadsheetId": "<ID>"}'
 ```
 
 Parse the JSON response to extract sheet titles and IDs. Filter out non-accelerator sheets:
@@ -63,8 +63,10 @@ If a sheet in the spreadsheet doesn't match any config entry, note it as unrecog
 For each accelerator sheet, read ALL rows (up to 50 rows) to capture all version track sections:
 
 ```bash
-gws sheets spreadsheets values get --params '{"spreadsheetId": "<ID>", "range": "'<sheet-name>'!A1:Z50"}' 2>/dev/null
+gws sheets spreadsheets values get --params '{"spreadsheetId": "<ID>", "range": "<sheet-name>!A1:Z50"}'
 ```
+
+Note: If a sheet name contains special characters (spaces, apostrophes), ensure proper JSON escaping in the `range` value.
 
 Parse the JSON `values` array. Each row is an array of cell values.
 
@@ -101,9 +103,9 @@ For each active track, scan its rows and extract version data from the target re
 |------------|-------------|
 | Accelerator version | Track header row, target column (e.g., "CUDA 12.9", "ROCm 7.2.x") |
 | Python | Row where column A contains "python" (case-insensitive) |
-| Torch | Row where any cell in the row contains "torch" |
-| vLLM | Row where any cell in the row contains "vllm" |
-| Extra versions | Match `extra_version_rows` patterns from variant config |
+| Torch | Row where column A contains "torch" (case-insensitive) |
+| vLLM | Row where column A contains "vllm" (case-insensitive) |
+| Extra versions | Match `extra_version_rows` patterns from variant config against column A |
 
 **Handling version values:**
 - If the cell contains `(?)` or `?`, keep the value but mark it as tentative: `"2.11 (?)"` → `"2.11 (?)"`
@@ -260,7 +262,7 @@ After generating the output files, the user may ask to create the actual JIRA ti
 
 Before creating any tickets, **always** perform these steps:
 
-1. **Read the release schedule spreadsheet** — The URL is in `jira-creation-config.yaml` under `schedule_spreadsheet`. Extract the spreadsheet ID and read all rows. Find the section matching the target release (e.g., "RH AI 3.5 EA2" as a row header). Extract key milestone dates from that section. Dates in the spreadsheet may lack a year — infer the year from context (current year or the release timeline). Present a table of key milestones to the user.
+1. **Read the release schedule spreadsheet** — The URL is in `jira-creation-config.yaml` under `schedule_spreadsheet`. Extract the spreadsheet ID and read all rows. Find the section matching the target release (e.g., "RH AI 3.5 EA2" as a row header). Extract key milestone dates from that section. Dates in the spreadsheet may lack a year — resolve using this precedence: (1) extract year from the release version string if present, (2) use surrounding dates in the schedule that do include a year, (3) current year as final fallback. Flag any inferred years for explicit user confirmation. Present a table of key milestones to the user.
 
 2. **Resolve due dates from milestones** — Use the milestone names in `jira-creation-config.yaml` to look up dates:
    - `due_dates.feature_milestone` → Feature due date (default: "AIPCC Code Freeze")

--- a/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/jira-creation-config.yaml
+++ b/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/jira-creation-config.yaml
@@ -1,0 +1,89 @@
+# JIRA Ticket Creation Configuration
+#
+# Defines the fields used when creating Features, Epics, Stories, and Tasks
+# in JIRA from the generated release template YAML.
+#
+# IMPORTANT: Update these values before each release cycle or when project
+# settings change. Replace all placeholder values marked with angle brackets
+# (<...>) with your team's actual values.
+
+project: AIPCC
+
+# Component applied to all created issues
+component: "AIPCC Ecosystems"
+
+# Label applied to all created issues (release-specific)
+label: null
+
+# Team field (Jira custom field customfield_10001)
+# Note: may not be settable via API due to screen restrictions.
+# If creation fails with team, set it manually on the board.
+team:
+  field: customfield_10001
+  id: "<team-id>"
+  name: "<team-name>"
+
+# Fix Version — can only be set at creation time via additionalAttributes.
+# Cannot be set via REST edit (screen restriction).
+# Format in additionalAttributes: "fixVersions": [{"name": "<value>"}]
+fix_version: "<fix-version>"
+
+# Due dates (REQUIRED — read from schedule spreadsheet, confirm with user)
+# Format: YYYY-MM-DD
+#
+# Source: release schedule spreadsheet (see schedule_spreadsheet below).
+# The skill reads the schedule, extracts milestone dates, presents them
+# to the user for confirmation, then applies them based on the mapping below.
+#
+# Default due dates by issue type (milestone name from schedule spreadsheet):
+#   - feature_milestone → all Features
+#   - epic_milestone    → all Epics (unless overridden below)
+# Stories and Tasks inherit their parent Epic's due date.
+due_dates:
+  feature_milestone: "AIPCC Code Freeze"
+  epic_milestone: "AIPCC Base Image Development"  # use the END date of the range
+
+# Per-epic due date overrides
+# Certain epics use a different milestone than the default.
+# Keys match epic summaries (or squad names); values are schedule milestone names.
+epic_due_date_overrides:
+  "Release AIPCC base images for {version}": "AIPCC Base Image RC"
+  "Public index": "AIPCC Package Index inital push to prod"
+
+# Release schedule spreadsheet
+# Contains milestone dates per release. The skill reads the section matching
+# the target release version (e.g., "RH AI 3.5 EA2") and extracts key dates.
+# Replace with the URL of your team's release schedule spreadsheet.
+schedule_spreadsheet: "<google-sheets-url>"
+
+# Target Version (customfield_10855) — version-type field
+# Can only be set at creation time via additionalAttributes, not via REST edit.
+# Format: "customfield_10855": [{"name": "<value>"}]
+target_version:
+  field: customfield_10855
+  value: "<target-version>"
+
+# Parent issue for all Features (set to null for top-level)
+parent: null
+
+# Issue creation order:
+#   1. Create Feature (top-level per variant)
+#   2. Create Epics as children of the Feature
+#   3. Create Stories/Tasks as children of their parent Epic
+#
+# Each issue is created via:
+#   acli jira workitem create --from-json <file>
+#
+# JSON template structure:
+# {
+#   "projectKey": "<project>",
+#   "type": "<Feature|Epic|Story|Task>",
+#   "summary": "<from release template>",
+#   "description": { ADF format },
+#   "assignee": "<from variant-config squad or default>",
+#   "additionalAttributes": {
+#     "components": [{"name": "<component>"}],
+#     "labels": ["<label>"],
+#     "parent": {"key": "<parent-key>"}  // omit for top-level Features
+#   }
+# }

--- a/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/jira-creation-config.yaml
+++ b/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/jira-creation-config.yaml
@@ -48,7 +48,7 @@ due_dates:
 # Keys match epic summaries (or squad names); values are schedule milestone names.
 epic_due_date_overrides:
   "Release AIPCC base images for {version}": "AIPCC Base Image RC"
-  "Public index": "AIPCC Package Index inital push to prod"
+  "{version} public index": "AIPCC Package Index inital push to prod"
 
 # Release schedule spreadsheet
 # Contains milestone dates per release. The skill reads the section matching

--- a/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/variant-config.yaml
+++ b/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/variant-config.yaml
@@ -393,5 +393,7 @@ jira_defaults:
   products:
     - RHAI
     - RHAAIS
+  # Default component for variant-level template output.
+  # The creation-time component (used when filing tickets) is in jira-creation-config.yaml.
   components:
     - Accelerator Enablement

--- a/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/variant-config.yaml
+++ b/helpers/skills/jira-aipcc-release-feature-epic-generator/assets/variant-config.yaml
@@ -1,0 +1,397 @@
+# Accelerator Variant Configuration for AIPCC Release Feature Generation
+#
+# This file defines:
+#   1. Which spreadsheet sheets map to which accelerators
+#   2. How to identify version tracks within each sheet
+#   3. Squad metadata (leads, assignees, labels, watchers)
+#   4. Epic templates per variant type
+#   5. Cross-cutting squad definitions
+#
+# Maintained as the single source of truth for JIRA issue structure.
+# Version data comes from the planning spreadsheet at runtime.
+#
+# IMPORTANT: Before first use, replace all placeholder values marked with
+# angle brackets (<...>) with your team's actual squad leads, Jira usernames,
+# and watcher lists.
+
+# ---------------------------------------------------------------------------
+# Spreadsheet structure
+# ---------------------------------------------------------------------------
+#
+# Each accelerator sheet follows this layout:
+#   Row 0: Status header (stable vs planning)
+#   Row 1: Release header — "Release:" | "prehistory" | "RHAI 3.3" | ...
+#   Row 2+: Version track sections, separated by blank rows
+#
+# A version track section starts with a header row where column A contains
+# the track name (e.g., "CUDA 12.9", "ROCm 7.1"). Subsequent rows contain:
+#   - Architecture (e.g., "x86_64 and aarch64")
+#   - Python version
+#   - Torch version
+#   - vLLM version
+#   - Additional packages (varies by accelerator)
+#   - GCC version
+#   - RHEL version
+#
+# Sheets that are NOT accelerator sheets and should be skipped:
+#   - "Retired - Planning 2026"
+#   - "Major related releases"
+#   - "Additional info"
+
+# ---------------------------------------------------------------------------
+# Row identification patterns
+# ---------------------------------------------------------------------------
+# These patterns match the first cell (column A) of data rows within a track
+# section. Used to extract version data from the correct row.
+
+row_patterns:
+  python: "python"
+  torch: "torch"
+  vllm: "vllm"
+  gcc: "GCC"
+  rhel: "RHEL"
+  triton: "triton"
+  tensorflow: "tensorflow"
+  nvshmem: "nvshmem"
+  llm_compressor: "llm-compressor"
+  speculators: "speculators"
+
+# ---------------------------------------------------------------------------
+# Accelerator sheet definitions
+# ---------------------------------------------------------------------------
+
+accelerator_sheets:
+
+  - sheet: "Intel Gaudi"
+    accelerator: gaudi
+    track_pattern: "Intel Gaudi"
+    variant_name_override: "gaudi"
+    variant_suffix: "-ubi9"
+    version_row_label: "Intel Gaudi"
+    squad:
+      name: Gaudi
+      lead: "<squad-lead-name>"
+      assignee: "<jira-username>"
+      labels: [aipcc-ae-gaudi]
+      watchers: []
+    epic_template: gaudi
+
+  - sheet: "CPU"
+    accelerator: cpu
+    track_pattern: "CPU"
+    variant_name_override: "cpu"
+    variant_suffix: "-ubi9"
+    version_row_label: null
+    squad:
+      name: CPU
+      lead: "<squad-lead-name>"
+      assignee: "<jira-username>"
+      labels: [aipcc-ae-cpu]
+      watchers: []
+    epic_template: cpu
+
+  - sheet: "Google TPU"
+    accelerator: tpu
+    track_pattern: "Google TPU"
+    variant_name_override: "tpu"
+    variant_suffix: "-ubi9"
+    version_row_label: "Google TPU"
+    extra_version_rows:
+      tpu_plugin: "TPU plugin"
+    squad:
+      name: TPU
+      lead: "<squad-lead-name>"
+      assignee: "<jira-username>"
+      labels: [aipcc-ae-tpu]
+      watchers: []
+    epic_template: standard_with_qe
+
+  - sheet: "AWS Neuron"
+    accelerator: neuron
+    track_pattern: "AWS Neuron"
+    variant_name_override: "neuron"
+    variant_suffix: "-ubi9"
+    version_row_label: "AWS Neuron"
+    extra_version_rows:
+      neuron_plugin: "Neuron plugin"
+    squad:
+      name: AWS Neuron
+      lead: "<squad-lead-name>"
+      assignee: "<jira-username>"
+      labels: [aipcc-ae-neuron]
+      watchers: []
+    epic_template: standard_with_ae_testplan
+
+  - sheet: "CUDA"
+    accelerator: cuda
+    track_pattern: "CUDA"
+    variant_suffix: "-ubi9"
+    version_row_label: "CUDA"
+    extra_version_rows:
+      nvshmem: "nvshmem"
+      llm_compressor: "llm-compressor"
+      speculators: "speculators"
+    squad:
+      name: CUDA
+      lead: "<squad-lead-name>"
+      assignee: "<jira-username>"
+      labels: [aipcc-ae-cuda]
+      watchers: []
+    # Epic template is selected per track:
+    #   - Tracks with "13" in the version get "cuda_with_modelopt"
+    #   - Others get "standard_with_qe"
+    epic_template_rules:
+      - match: "13"
+        template: cuda_with_modelopt
+      - default: standard_with_qe
+
+  - sheet: "Spyre"
+    accelerator: spyre
+    track_pattern: "Spyre"
+    variant_name_override: "spyre"
+    variant_suffix: "-ubi9"
+    version_row_label: "Spyre"
+    extra_version_rows:
+      spyre_plugin: "Spyre plugin"
+    squad:
+      name: IBM Spyre
+      lead: "<squad-lead-name>"
+      assignee: "<jira-username>"
+      labels: [aipcc-ae-spyre]
+      watchers: []
+    epic_template: spyre
+
+  - sheet: "ROCm"
+    accelerator: rocm
+    track_pattern: "ROCm"
+    variant_suffix: "-ubi9"
+    version_row_label: "ROCm"
+    squad:
+      name: ROCm
+      lead: "<squad-lead-name>"
+      assignee: "<jira-username>"
+      labels: [aipcc-ae-rocm]
+      watchers: []
+    epic_template: rocm
+
+# ---------------------------------------------------------------------------
+# Epic templates
+# ---------------------------------------------------------------------------
+# Each template defines the set of Epics (and optionally Stories/Tasks)
+# created as children of the variant's Feature.
+#
+# Placeholders:
+#   {variant}      — Full variant name (e.g., "cuda12.9-ubi9")
+#   {version}      — Release version (e.g., "3.5-EA2")
+#   {torch}        — Torch version from spreadsheet
+#   {vllm}         — vLLM version from spreadsheet
+#   {accel_version}— Accelerator-specific version from spreadsheet
+#   {accelerator}  — Accelerator display name (e.g., "CUDA", "ROCm 7.1")
+
+epic_templates:
+
+  gaudi:
+    children:
+      - type: Epic
+        summary: "Update gaudi-ubi9 stack to {accel_version}"
+        description: "Update the Gaudi SDK/driver stack in base images and builder."
+      - type: Epic
+        summary: "Update torch to {torch}"
+      - type: Epic
+        summary: "Update vllm to {vllm}"
+
+  cpu:
+    children:
+      - type: Epic
+        summary: "Prepare for torch {torch} support for {version} {variant}"
+        children:
+          - type: Story
+            summary: "[Step 1] Update builder to support torch {torch} in {variant}"
+          - type: Story
+            summary: "[Step 2] Ensure that builder version in RHAI pipeline is updated"
+          - type: Story
+            summary: "[Step 3] Create MR that adds torch and dependant packages to deletion YAML config."
+          - type: Story
+            summary: "[Step 4] Create MR that updates torch to {torch} in RHAI {version} pipeline for {variant}"
+      - type: Epic
+        summary: "Update RHAI {version} pipeline to torch {torch}"
+        children:
+          - type: Story
+            summary: "[Step 1] Announce that RHAI pipeline is being updated to torch {torch}"
+          - type: Story
+            summary: "[Step 2] Delete old versions of torch and dependant packages in {version} {variant}"
+          - type: Story
+            summary: "[Step 3] Revert the deletion YAML config entries"
+          - type: Story
+            summary: "[Step 4] Merge the MR that updates torch to {torch} in RHAI {version} pipeline for {variant}"
+          - type: Story
+            summary: "[Step 5] Announce that RHAI pipeline is updated to torch {torch}"
+      - type: Epic
+        summary: "Deliver {variant} wheels for vLLM {vllm} for {version}"
+        children:
+          - type: Story
+            summary: "Update builder to support vLLM {vllm} in {variant}"
+          - type: Story
+            summary: "Update RHAI pipeline to build vLLM {vllm} for {variant}"
+
+  standard_with_qe:
+    children:
+      - type: Epic
+        summary: "Update {variant} base images for {version}"
+      - type: Epic
+        summary: "Update torch to {torch}"
+      - type: Epic
+        summary: "Update vllm to {vllm}"
+      - type: Epic
+        summary: "QE: Validate {accelerator} packages for {version}"
+
+  cuda_with_modelopt:
+    children:
+      - type: Epic
+        summary: "Update {variant} base images for {version}"
+      - type: Epic
+        summary: "Update torch to {torch}"
+      - type: Epic
+        summary: "Update vllm to {vllm}"
+      - type: Epic
+        summary: "Update Model-Opt packages (speculators, llmcompressor)"
+      - type: Epic
+        summary: "QE: Validate CUDA packages for {version}"
+
+  standard_with_ae_testplan:
+    children:
+      - type: Epic
+        summary: "Update {variant} stack for {version}"
+      - type: Epic
+        summary: "Update torch to {torch}"
+      - type: Epic
+        summary: "Update vllm to {vllm}"
+      - type: Epic
+        summary: "AE TestPlan: Validate {accelerator} for {version}"
+
+  rocm:
+    children:
+      - type: Epic
+        summary: "Update {variant} stack for {version}"
+      - type: Epic
+        summary: "Update torch to {torch}"
+      - type: Epic
+        summary: "Update vllm to {vllm}"
+      - type: Epic
+        summary: "AE Test Plan for {version} for {accelerator}"
+
+  spyre:
+    children:
+      - type: Epic
+        summary: "Update wheels in the builder collection"
+      - type: Epic
+        summary: "Update wheel collections"
+        description: "Update wheel collections to support new package builds."
+        children:
+          - type: Story
+            summary: "Update wheel collection in rhaiis/pipeline"
+          - type: Story
+            summary: "Update wheel collections in rhai/pipeline"
+      - type: Epic
+        summary: "RHAII Containerfile/environment variable updates"
+        description: "Update RHAII containerfile/env variable/entrypoint to support new Spyre stack."
+      - type: Epic
+        summary: "Create and share RC images for test with IBM"
+        description: "Create and share RC images for test with IBM, depends on base image and wheel collections being delivered."
+      - type: Epic
+        summary: "Create customer-facing base images for IBM Spyre"
+        description: "Create final customer-facing base images for IBM Spyre, depends on RC images being delivered and testing."
+
+# ---------------------------------------------------------------------------
+# Feature template
+# ---------------------------------------------------------------------------
+# The Feature wrapping each variant's epics.
+
+feature_template:
+  type: Feature
+  summary: "{variant} for {version}"
+  description: >-
+    This issue tracks the requirements to update the {accelerator} stack for {version}.
+
+# ---------------------------------------------------------------------------
+# Cross-cutting squads
+# ---------------------------------------------------------------------------
+# These are not per-variant — they produce a fixed set of issues per release.
+
+cross_cutting_squads:
+
+  - name: base-images
+    labels: [aipcc-base-images]
+    template:
+      - type: Epic
+        summary: "Release AIPCC base images for {version}"
+        description: >-
+          This epic will have tasks that are involved in release of AIPCC base images.
+        assignee: "<jira-username>"
+        watchers: []
+        children:
+          - type: Task
+            summary: "Create {version} branch"
+          - type: Task
+            summary: "Update to {version} RHAI production index before branching"
+          - type: Task
+            summary: "Update to RPM repository before branching"
+          - type: Task
+            summary: "Push {version} base images to Production"
+          - type: Task
+            summary: "After branching update main branch to use the next test index"
+
+  - name: delivery
+    labels: [aipcc-delivery]
+    template:
+      - type: Feature
+        summary: "Delivery Squad work for {version}"
+        description: >-
+          This issue tracks delivery squad work for {version}.
+        assignee: "<jira-username>"
+        watchers: []
+        children:
+          - type: Epic
+            summary: "Branch RHAI wheel pipeline for {version}"
+            children:
+              - type: Story
+                summary: "Step 0: Copy wheels from {prev_version} to {version} distribution"
+              - type: Story
+                summary: "Step 1: Create infrastructure for the {version} builds"
+              - type: Story
+                summary: "Step 2: Set PRODUCT_VERSION to {version} on main"
+              - type: Story
+                summary: "Enable test jobs for onboarding collections"
+              - type: Story
+                summary: "Publish newest {prev_version} wheels to production"
+              - type: Story
+                summary: "Step 3: Enable Repeatable builds in {prev_version} release branch"
+              - type: Story
+                summary: "Step 4: Configure renovate regex for release branch"
+              - type: Story
+                summary: "Step 5: Disable nightly builds in {prev_version} protected branch"
+              - type: Story
+                summary: "Announce branching finalization"
+              - type: Story
+                summary: "Backports to {prev_version}"
+          - type: Epic
+            summary: "{version} public index"
+            children:
+              - type: Story
+                summary: "[{version} ongoing] Publish the production indexes"
+              - type: Story
+                summary: "[{version} ongoing] Trigger all out index tests"
+          - type: Epic
+            summary: "Bugs in packages found during the wide RHAI {version} testing"
+
+# ---------------------------------------------------------------------------
+# JIRA defaults
+# ---------------------------------------------------------------------------
+
+jira_defaults:
+  project: AIPCC
+  products:
+    - RHAI
+    - RHAAIS
+  components:
+    - Accelerator Enablement


### PR DESCRIPTION
## Summary

- Adds `jira-aipcc-release-feature-epic-generator` skill that generates JIRA Features, Epics, Stories, and Tasks for an AIPCC release
- Reads accelerator variant data from a Google Sheets planning spreadsheet and applies configurable epic templates
- Includes two config assets: `variant-config.yaml` (accelerator/squad/template definitions) and `jira-creation-config.yaml` (JIRA field defaults)
- Personal data (names, usernames, internal URLs) replaced with `<placeholder>` values for users to fill in

## Type of contribution

- [x] New skill
- [ ] Bug fix
- [ ] Documentation

## Testing and validation

- [x] `make update` ran successfully (skill recognized, settings regenerated)
- [x] `make lint` — skillsaw passed with grade A
- [x] No secrets, credentials, or personal identifiers in committed files
- [x] Categorized under AIPCC in `categories.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating JIRA release features, epics, stories, and tasks from release and spreadsheet inputs.
  * Added new configuration options for release scheduling, issue fields, and variant-based ticket generation.
  * Expanded supported accelerator variants and release templates, including handling for new, active, discontinued, and missing version data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->