### PR TITLE
Add github-actions-debugger skill

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -274,6 +274,14 @@
         "allowed_tools": "Bash"
       },
       {
+        "name": "github-actions-debugger",
+        "description": "Debug and monitor GitHub Actions workflow runs. Check run status, view failed job logs, and troubleshoot CI failures. Use this when the user needs to investigate GitHub Actions failures, inspect job output, or identify the root cause of a broken workflow run.",
+        "category": "general",
+        "file_path": "helpers/skills/github-actions-debugger/SKILL.md",
+        "id": "github-actions-debugger",
+        "allowed_tools": "Bash(gh:*)"
+      },
+      {
         "name": "github-sync-upstream",
         "description": "Sync code from an upstream GitHub repository into a target fork (e.g., opendatahub-io midstream). Detects remotes from the current repo, or clones fresh if run from outside. Fetches upstream, merges into a sync branch, restores protected files, resolves conflicts, and opens a PR to the target GitHub repo. Use when asked to sync upstream, merge upstream changes, or bring a GitHub fork up to date with its upstream source.",
         "category": "git workflows",

--- a/helpers/skills/github-actions-debugger/SKILL.md
+++ b/helpers/skills/github-actions-debugger/SKILL.md
@@ -34,10 +34,11 @@ When the user provides a full GitHub Actions URL, parse it to extract the reposi
 then use `-R` to target that repository. **Always use the repository from the URL, ignoring the local git remote.**
 
 Before constructing any command from a URL, validate the extracted values:
-- Repository paths must only contain letters, digits, hyphens, underscores, and a single forward slash.
+- Owner names must only contain letters, digits, and hyphens.
+- Repository names must only contain letters, digits, hyphens, underscores, and dots.
 - Run IDs and job IDs must be purely numeric.
 - Workflow file names must only contain letters, digits, hyphens, underscores, and dots.
-If any value fails validation, reject it and ask the user to provide a corrected URL or ID.
+If any extracted value fails its rule, reject it and ask the user to provide a corrected URL or ID.
 
 - **Run URL** format: `https://github.com/<owner>/<repo>/actions/runs/<run-id>`
   - Extract: `-R <owner>/<repo>` and `<run-id>`

--- a/helpers/skills/github-actions-debugger/SKILL.md
+++ b/helpers/skills/github-actions-debugger/SKILL.md
@@ -18,9 +18,9 @@ This skill enables Claude to investigate GitHub Actions failures by:
 - `gh` CLI installed and authenticated (`gh auth status` to verify)
 - Git repository with a GitHub remote configured (for automatic repo detection)
 
-If `gh` is not installed or authenticated, provide setup instructions:
-- Install: https://cli.github.com/
-- Authenticate: `gh auth login`
+If `gh` is not installed, ask the user to follow installation instructions at https://cli.github.com/
+
+If `gh` is not authenticated, ask the user to run `gh auth login`.
 
 ## Instructions
 
@@ -116,8 +116,6 @@ gh run rerun 123456789 --failed
 
 ## Error Handling
 
-- If `gh` is not found, instruct the user to install it from https://cli.github.com/
-- If `gh auth status` reports unauthenticated, instruct the user to run `gh auth login`
 - If a run ID is not found, show the error and suggest running `gh run list` to find the correct ID
 - If the repository cannot be detected, suggest using `-R <owner>/<repo>` or running from within the correct git repository
 - If logs are unavailable (e.g., run too old or log retention expired), inform the user and suggest checking the GitHub Actions UI directly

--- a/helpers/skills/github-actions-debugger/SKILL.md
+++ b/helpers/skills/github-actions-debugger/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: github-actions-debugger
+description: Debug and monitor GitHub Actions workflow runs. Check run status, view failed job logs, and troubleshoot CI failures. Use this when the user needs to investigate GitHub Actions failures, inspect job output, or identify the root cause of a broken workflow run.
+allowed-tools: Bash(gh:*)
+---
+
+# GitHub Actions Debugger
+
+This skill enables Claude to investigate GitHub Actions failures by:
+
+1. Listing recent workflow runs and their status
+2. Identifying failed jobs within a run
+3. Retrieving failed job logs
+4. Analyzing error messages and suggesting next debugging steps
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth status` to verify)
+- Git repository with a GitHub remote configured (for automatic repo detection)
+
+If `gh` is not installed or authenticated, provide setup instructions:
+- Install: https://cli.github.com/
+- Authenticate: `gh auth login`
+
+## Instructions
+
+When the user asks to check CI status, debug workflow failures, or view job logs, use the `gh` CLI commands below.
+All commands auto-detect the GitHub repository from the git remote in the current working directory.
+To target a different repository, add `-R <owner>/<repo>` to any command.
+
+### Handling GitHub Actions URLs
+
+When the user provides a full GitHub Actions URL, parse it to extract the repository and run or job ID,
+then use `-R` to target that repository. **Always use the repository from the URL, ignoring the local git remote.**
+
+Before constructing any command from a URL, validate the extracted values:
+- Repository paths must only contain letters, digits, hyphens, underscores, and a single forward slash.
+- Run IDs and job IDs must be purely numeric.
+- Workflow file names must only contain letters, digits, hyphens, underscores, and dots.
+If any value fails validation, reject it and ask the user to provide a corrected URL or ID.
+
+- **Run URL** format: `https://github.com/<owner>/<repo>/actions/runs/<run-id>`
+  - Extract: `-R <owner>/<repo>` and `<run-id>`
+  - Example: `https://github.com/my-org/my-project/actions/runs/123456789`
+    becomes `gh run view 123456789 -R my-org/my-project`
+
+- **Workflow URL** format: `https://github.com/<owner>/<repo>/actions/workflows/<workflow-file>`
+  - Extract: `-R <owner>/<repo>` and `--workflow <workflow-file>`
+  - Example: `https://github.com/my-org/my-project/actions/workflows/ci.yaml`
+    becomes `gh run list --workflow ci.yaml -R my-org/my-project`
+
+### Commands
+
+1. **List Recent Workflow Runs**
+    - Run `gh run list --limit 10` to show the latest runs with their status, workflow name, and run ID
+    - Add `--status failure` to filter for only failed runs:
+      `gh run list --status failure --limit 10`
+
+2. **Filter by Workflow File**
+    - Use `--workflow` to scope results to a specific workflow:
+      `gh run list --workflow ci.yaml --limit 10`
+
+3. **View a Specific Run**
+    - Use `gh run view <run-id>` to see the run summary including all jobs and their status:
+      `gh run view <run-id>`
+    - Add `--log-failed` to immediately stream the logs of all failed jobs:
+      `gh run view <run-id> --log-failed`
+
+4. **View Full Logs for a Run**
+    - To retrieve complete logs for every job in a run:
+      `gh run view <run-id> --log`
+    - Pipe through `grep` to isolate errors:
+      `gh run view <run-id> --log-failed 2>&1 | grep -i "error\|fail\|fatal" | head -50`
+
+5. **Watch a Running Workflow**
+    - To follow a currently active run in real time:
+      `gh run watch <run-id>`
+
+6. **Re-run Failed Jobs**
+    - If the user wants to retry only the failed jobs without re-running passing ones:
+      `gh run rerun <run-id> --failed`
+
+7. **Troubleshoot CI Failures**
+    - First, list recent failed runs to identify the run ID (step 1)
+    - Then, view the run to see which jobs failed (step 3)
+    - Then, retrieve the failed job logs (step 3 with `--log-failed`)
+    - Analyze the log output to identify the root cause and suggest fixes
+
+## Examples
+
+```bash
+# List the 10 most recent runs across all workflows
+gh run list --limit 10
+```
+
+```bash
+# Show only failed runs for a specific workflow
+gh run list --workflow ci.yaml --status failure --limit 10
+```
+
+```bash
+# View run summary and failed job logs for run ID 123456789
+gh run view 123456789 --log-failed
+```
+
+```bash
+# Grep failed logs for actionable errors
+gh run view 123456789 --log-failed 2>&1 | grep -i "error\|fail\|fatal" | head -50
+```
+
+```bash
+# Re-run only the failed jobs
+gh run rerun 123456789 --failed
+```
+
+## Error Handling
+
+- If `gh` is not found, instruct the user to install it from https://cli.github.com/
+- If `gh auth status` reports unauthenticated, instruct the user to run `gh auth login`
+- If a run ID is not found, show the error and suggest running `gh run list` to find the correct ID
+- If the repository cannot be detected, suggest using `-R <owner>/<repo>` or running from within the correct git repository
+- If logs are unavailable (e.g., run too old or log retention expired), inform the user and suggest checking the GitHub Actions UI directly

--- a/helpers/skills/gitlab-pipeline-debugger/SKILL.md
+++ b/helpers/skills/gitlab-pipeline-debugger/SKILL.md
@@ -18,9 +18,9 @@ This skill enables Claude to investigate GitLab CI pipeline failures by:
 - `glab` CLI installed and authenticated (`glab auth status` to verify)
 - Git repository with GitLab remote configured (for automatic repo detection)
 
-If `glab` is not installed or authenticated, provide instructions for setting it up:
-- Install: https://gitlab.com/gitlab-org/cli#installation
-- Authenticate: `glab auth login`
+If `glab` is not installed, ask the user to follow installation instructions at https://gitlab.com/gitlab-org/cli#installation
+
+If `glab` is not authenticated, ask the user to run `glab auth login`.
 
 ## Instructions
 
@@ -97,8 +97,6 @@ glab ci trace 789012 -R my-org/my-project
 
 ## Error Handling
 
-- If `glab` is not found, instruct the user to install it
-- If `glab auth status` reports unauthenticated, instruct the user to run `glab auth login`
 - If a pipeline or job is not found, show the error and suggest checking the ID or branch name
 - If the repo cannot be detected, suggest using `-R <owner/group/project>` or running from within
   the correct git repository


### PR DESCRIPTION
## Summary

- Adds a new `github-actions-debugger` skill under `helpers/skills/`
- Enables Claude to debug GitHub Actions CI failures using the `gh` CLI
- Mirrors the existing `gitlab-pipeline-debugger` skill pattern, filling the natural GitHub-side gap

## What the skill does

- Lists recent workflow runs filtered by status or workflow file
- Views run summaries and identifies failed jobs
- Streams failed job logs with `--log-failed`
- Handles full GitHub Actions URLs (run URLs and workflow URLs) with input validation
- Suggests re-running only failed jobs with `gh run rerun --failed`
- Provides error handling for unauthenticated `gh`, missing run IDs, and expired log retention

## Checklist

- [x] Skill directory created at `helpers/skills/github-actions-debugger/`
- [x] `SKILL.md` includes required `name` and `description` frontmatter
- [x] `allowed-tools` scoped to `Bash(gh:*)`
- [x] `make update` run — skill registered as #75, picked up in `docs/data.json`
- [x] `make lint` (skillsaw) — Grade A, 0 errors, 0 warnings

## Prior art

This skill is modelled after `gitlab-pipeline-debugger` (which uses `glab`). The two skills now provide symmetric CI debugging coverage for GitLab and GitHub hosted repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new GitHub Actions troubleshooting skill with step-by-step guidance for finding runs, reviewing logs, watching live progress, and rerunning failed jobs.
  * Included validation and examples for working with GitHub Actions URLs more reliably.
  * Registered the new skill so it’s discoverable in the available tools list.
* **Documentation**
  * Updated the GitLab pipeline debugger guidance to clarify installing `glab` and running `glab auth login` when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->