### PR TITLE
feat(llm-d): add ai-gateway-operator manifest update skill

### DIFF
--- a/docs/data.json
+++ b/docs/data.json
@@ -125,6 +125,14 @@
         "file_path": "plugins/odh-jira/skills/ai-bug-fix-triage/SKILL.md"
       },
       {
+        "name": "ai-gateway-operator-manifest-update",
+        "id": "ai-gateway-operator-manifest-update",
+        "description": "Update batch-gateway manifests in opendatahub-io/ai-gateway-operator when the pinned llm-d-batch-gateway-operator main commit changes.",
+        "category": "odh-llm-d",
+        "allowed_tools": "",
+        "file_path": "plugins/odh-llm-d/skills/ai-gateway-operator-manifest-update/SKILL.md"
+      },
+      {
         "name": "aipcc-commit-suggest",
         "id": "aipcc-commit-suggest",
         "description": "Generate AIPCC Commits style commit messages or summarize existing commits",

--- a/plugins/odh-llm-d/skills/ai-gateway-operator-manifest-update/SKILL.md
+++ b/plugins/odh-llm-d/skills/ai-gateway-operator-manifest-update/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ai-gateway-operator-manifest-update
+description: Update batch-gateway manifests in opendatahub-io/ai-gateway-operator when the pinned llm-d-batch-gateway-operator main commit changes.
+---
+
+# Ai Gateway Operator Manifest Update
+
+Use this skill for updating the batch-gateway manifests in the local
+ai-gateway-operator checkout.
+
+Run the helper:
+
+~~~bash
+bash scripts/update_manifests.sh
+~~~
+
+Run it from the ai-gateway-operator checkout, or pass another checkout with
+`--repo PATH`. Automation should pass its local checkout path explicitly.
+
+The helper reads the [batchgateway] SHA from
+hack/scripts/get-manifests.sh, resolves refs/heads/main from
+https://github.com/opendatahub-io/llm-d-batch-gateway-operator, and compares
+commit ancestry. It exits without changes when the SHAs match or when the
+OpenDataHub commit is not newer than the local pin. When OpenDataHub has a
+newer commit, it updates the ODH SHA and runs make get-manifests.
+
+After a change:
+
+- Inspect the diff. Keep the pin and generated files under
+  config/manifests/batchgateway/; do not include unrelated component output.
+- Run git diff --check and
+  kustomize build config/manifests/batchgateway/default.
+- Report the old SHA, new SHA, changed files, and validation results.
+
+The helper updates local files only. Committing and publishing changes are
+outside this skill's scope.

--- a/plugins/odh-llm-d/skills/ai-gateway-operator-manifest-update/agents/openai.yaml
+++ b/plugins/odh-llm-d/skills/ai-gateway-operator-manifest-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Gateway Operator Manifest Update"
+  short_description: "Update batch-gateway manifests in ai-gateway-operator"
+  default_prompt: "Check the latest batch-gateway-operator commit and update ai-gateway-operator manifests when needed."

--- a/plugins/odh-llm-d/skills/ai-gateway-operator-manifest-update/scripts/update_manifests.sh
+++ b/plugins/odh-llm-d/skills/ai-gateway-operator-manifest-update/scripts/update_manifests.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO=""
+UPSTREAM_REPO="https://github.com/opendatahub-io/llm-d-batch-gateway-operator.git"
+UPSTREAM_REF="refs/heads/main"
+
+usage() {
+    echo "Usage: $0 [--repo PATH]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            REPO="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$REPO" ]]; then
+    REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+        echo "ERROR: run from a Git checkout or pass --repo PATH" >&2
+        exit 1
+    }
+fi
+
+SCRIPT="$REPO/hack/scripts/get-manifests.sh"
+[[ -d "$REPO/.git" ]] || { echo "ERROR: not a Git checkout: $REPO" >&2; exit 1; }
+[[ -f "$SCRIPT" ]] || { echo "ERROR: missing $SCRIPT" >&2; exit 1; }
+
+current_sha="$(
+    sed -nE 's/^[[:space:]]*\[batchgateway\]="[^"]*\|config\|([0-9a-f]{40})(\|[0-9a-f]{40})?".*/\1/p' "$SCRIPT"
+)"
+[[ "$current_sha" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "ERROR: could not read the batchgateway SHA from $SCRIPT" >&2
+    exit 1
+}
+
+latest_sha="$(git ls-remote "$UPSTREAM_REPO" "$UPSTREAM_REF" | awk 'NR == 1 { print $1 }')"
+[[ "$latest_sha" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "ERROR: could not resolve $UPSTREAM_REPO $UPSTREAM_REF" >&2
+    exit 1
+}
+
+if [[ "$current_sha" == "$latest_sha" ]]; then
+    printf 'UP-TO-DATE\t%s\n' "$current_sha"
+    exit 0
+fi
+
+compare_dir="$(mktemp -d -t ai-gateway-operator-compare.XXXXXXXXXX)"
+trap 'rm -rf "$compare_dir"' EXIT
+git -C "$compare_dir" init -q
+git -C "$compare_dir" remote add origin "$UPSTREAM_REPO"
+if ! git -C "$compare_dir" fetch --quiet origin "$current_sha" "$latest_sha"; then
+    echo "ERROR: could not fetch the local and upstream commits for ancestry check" >&2
+    exit 1
+fi
+if git -C "$compare_dir" merge-base --is-ancestor "$current_sha" "$latest_sha"; then
+    :
+else
+    status=$?
+    if [[ "$status" == 1 ]]; then
+        printf 'NOT-NEWER\t%s\t%s\n' "$current_sha" "$latest_sha"
+        exit 0
+    fi
+    echo "ERROR: could not determine commit ancestry" >&2
+    exit "$status"
+fi
+
+if [[ -n "$(git -C "$REPO" status --porcelain)" ]]; then
+    echo "ERROR: checkout has local changes; refusing to update: $REPO" >&2
+    git -C "$REPO" status --short >&2
+    exit 1
+fi
+
+sed -i -E "s/(^[[:space:]]*\[batchgateway\]=\"[^|]*\|config\|)[0-9a-f]{40}/\1$latest_sha/" "$SCRIPT"
+make -C "$REPO" get-manifests
+
+printf 'UPDATED\t%s\t%s\n' "$current_sha" "$latest_sha"


### PR DESCRIPTION
# Pull Request Description

## Summary

Add a skill that updates `ai-gateway-operator` batch-gateway manifests when
OpenDataHub publishes a newer `llm-d-batch-gateway-operator` commit.

## Type of Contribution

- [ ] 📝 New command
- [x] 🎯 New skill
- [ ] 🤖 New agent
- [ ] 💎 New Gemini Gem
- [ ] 📚 Documentation update
- [ ] 🐛 Bug fix
- [ ] 🔄 Refactoring/cleanup
- [ ] 🏗️ Infrastructure/tooling
- [ ] 📋 New category addition

## Changes Made

- Add `ai-gateway-operator-manifest-update` under `plugins/odh-llm-d/skills/`.
- Resolve the latest `main` commit from
  `opendatahub-io/llm-d-batch-gateway-operator`.
- Compare commit ancestry so older or unrelated pins are not downgraded.
- Update `hack/scripts/get-manifests.sh` and run `make get-manifests` only when
  OpenDataHub has a newer commit.
- Discover the checkout with Git or accept an explicit `--repo PATH`.
- Keep committing and publishing outside the skill's scope.

## Tool Details

### Skill

- **Skill name**: `ai-gateway-operator-manifest-update`
- **Primary use case**: Keep the batch-gateway manifests in
  `ai-gateway-operator` aligned with the latest OpenDataHub operator commit.
- **Dependencies required**: Git, Bash, `sed`, `awk`, and `make`.

## Testing and Validation

### Required Checks

- [ ] 🔄 Ran `make update` and committed any generated changes
- [ ] ✅ Ran `make lint` and all checks pass
- [x] 🧪 Tested the new functionality locally

### Platform Testing

- [ ] Claude Code: Tested commands/skills/agents integration
- [ ] Cursor AI: Tested tool integration (if applicable)
- [ ] Gemini: Created Gem in Gemini platform and verified sharing link works (if applicable)

## Categorization

- [x] Tool is placed in the appropriate `plugins/<plugin>/` directory (or a new plugin directory for a new category)

## Ethical Guidelines Compliance

- [x] ✅ No real people are referenced by name in examples or documentation
- [x] Qualities and styles are described explicitly rather than by reference to individuals

## Documentation

- [ ] Updated relevant README files if needed
- [x] Added appropriate usage instructions
- [x] Followed naming conventions for the platform

## Dependencies and Requirements

- [x] Shell helper has an executable shebang and executable permissions.
- [x] No undocumented runtime dependency beyond Git, Bash, standard Unix tools, and Make.

## Additional Notes

- The helper reports `UP-TO-DATE` when the local pin already matches the
  OpenDataHub `main` commit.
- The helper was tested with the current `b69437c` pin and with an isolated
  update from `c42e63a` to `b69437c`.
- The helper updates local files only; callers decide whether to commit or
  publish changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a workflow for updating AI Gateway Operator batch-gateway manifests to newer upstream revisions.
  - Supports specifying a local checkout, checking whether updates are available, validating repository state, and regenerating manifests.
  - Reports current and updated revisions and verifies changes before completing.
  - Added an AI agent configuration with display information and a default prompt.

- **Documentation**
  - Documented update requirements, validation steps, diff and build expectations, and clarified that committing and publishing are outside the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->